### PR TITLE
fix: Mod+S abre Discover en lugar de churros-store

### DIFF
--- a/archiso/airootfs/etc/skel/.config/niri/config.kdl
+++ b/archiso/airootfs/etc/skel/.config/niri/config.kdl
@@ -104,7 +104,7 @@ binds {
     Mod+C { spawn "churros-control-center"; }
     Mod+P { spawn "churros-settings"; }
     Mod+W { spawn "churros-welcome"; }
-    Mod+S { spawn "churros-store"; }
+    Mod+S { spawn "plasma-discover"; }
     Mod+E { spawn "thunar"; }
     Mod+Shift+E { spawn "churros-popup" "power"; }
     Mod+Shift+N { spawn "churros-popup" "network"; }


### PR DESCRIPTION
Parte de #4.

El atajo apuntaba a churros-store, que ya no existe desde 1da6a8e. Ahora lanza plasma-discover, que es el binario del paquete discover que ya está en packages.x86_64.