### PR TITLE
fix: señales correctas al recargar tema en waybar y foot

### DIFF
--- a/archiso/airootfs/usr/share/churros/preferences/services/theme.py
+++ b/archiso/airootfs/usr/share/churros/preferences/services/theme.py
@@ -95,9 +95,11 @@ class ThemeService:
 
         env = _build_env()
 
+        # waybar: SIGUSR2 recarga, SIGUSR1 solo alterna la visibilidad
+        # foot: SIGUSR1 cambia a [colors-dark], SIGUSR2 a [colors-light]
         for sig_target in (
-            ["pkill", "-SIGUSR1", "waybar"],
-            ["pkill", "-SIGUSR1", "kitty"],
+            ["pkill", "-SIGUSR2", "waybar"],
+            ["pkill", "-SIGUSR1" if dark else "-SIGUSR2", "foot"],
         ):
             try:
                 subprocess.run(

--- a/docs/preferences.md
+++ b/docs/preferences.md
@@ -233,7 +233,7 @@ CSS:
 3. **Cambia el wallpaper automáticamente**:
    - Dark → `/usr/share/churros/wallpapers/fondo1.png`
    - Light → `/usr/share/churros/wallpapers/default.jpeg`
-4. Envía `SIGUSR1` a waybar/kitty para recarga suave.
+4. Envía `SIGUSR2` a waybar (recarga) y a foot `SIGUSR1`/`SIGUSR2` según el modo (oscuro/claro).
 
 `WallpaperService.apply(path)`:
 


### PR DESCRIPTION
Parte de #4.

Al cambiar de tema, waybar recibía SIGUSR1, que por defecto oculta la barra en vez de recargarla. Ahora usa SIGUSR2, que es la señal de recarga (igual que ya hace usr/local/bin/churros-theme).

La otra señal iba a kitty, que no está en la distro. foot usa SIGUSR1 para [colors-dark] y SIGUSR2 para [colors-light], así que ahora depende del modo.