### PR TITLE
fix: quitar paquetes duplicados en packages.x86_64

### DIFF
--- a/archiso/packages.x86_64
+++ b/archiso/packages.x86_64
@@ -204,8 +204,6 @@ bluez-utils
 brightnessctl
 gsettings-desktop-schemas
 ufw
-xdg-desktop-portal
-xdg-desktop-portal-gtk
 plymouth
 papirus-icon-theme
 adwaita-icon-theme


### PR DESCRIPTION
Parte de #4.

xdg-desktop-portal y xdg-desktop-portal-gtk aparecían dos veces en packages.x86_64 (líneas 162-163 y 207-208). Pacman los deduplica, pero la lista quedaba confusa.