### PR TITLE
fix: color del borde de ventanas

### DIFF
--- a/archiso/airootfs/etc/skel/.config/niri/config.kdl
+++ b/archiso/airootfs/etc/skel/.config/niri/config.kdl
@@ -33,6 +33,9 @@ input {
 // Layout
 layout {
     gaps 8
+    focus-ring {
+        off
+    }
     border {
         on
         width 2


### PR DESCRIPTION
## Resumen
- Desactiva el focus-ring azul por defecto de Niri para que se vea el borde naranja (`#DE8636`).