### PR TITLE
fix: remove churros-store shortcut, replace with Discover

### DIFF
--- a/archiso/airootfs/etc/skel/.config/niri/config.kdl
+++ b/archiso/airootfs/etc/skel/.config/niri/config.kdl
@@ -104,7 +104,7 @@ binds {
     Mod+C { spawn "churros-control-center"; }
     Mod+P { spawn "churros-settings"; }
     Mod+W { spawn "churros-welcome"; }
-    Mod+S { spawn "churros-store"; }
+    Mod+S { spawn "discover"; }
     Mod+E { spawn "thunar"; }
     Mod+Shift+E { spawn "churros-popup" "power"; }
     Mod+Shift+N { spawn "churros-popup" "network"; }


### PR DESCRIPTION
Mod+S lanzaba churros-store, which no longer exists since the migration to KDE Discover (commit 1da6a8e). The shortcut was dead and did nothing.\n\nReplaced with 'discover' so Mod+S opens the installed package manager.