### PR TITLE
fix: remove pkill SIGUSR1 kitty from theme reload (terminal is foot)

### DIFF
--- a/archiso/airootfs/usr/share/churros/preferences/services/theme.py
+++ b/archiso/airootfs/usr/share/churros/preferences/services/theme.py
@@ -97,7 +97,6 @@ class ThemeService:
 
         for sig_target in (
             ["pkill", "-SIGUSR1", "waybar"],
-            ["pkill", "-SIGUSR1", "kitty"],
         ):
             try:
                 subprocess.run(


### PR DESCRIPTION
ChurrOS uses foot as terminal, NOT kitty. The pkill -SIGUSR1 kitty in ThemeService.set() was a dead code line that never reloaded the terminal on theme change.\n\nSince foot does not support theme reload via Unix signal, the fix is to remove the line entirely rather than pretending it works.