### PR TITLE
fix: remove duplicate xdg-desktop-portal entries in packages.x86_64

### DIFF
--- a/archiso/packages.x86_64
+++ b/archiso/packages.x86_64
@@ -204,8 +204,6 @@ bluez-utils
 brightnessctl
 gsettings-desktop-schemas
 ufw
-xdg-desktop-portal
-xdg-desktop-portal-gtk
 plymouth
 papirus-icon-theme
 adwaita-icon-theme


### PR DESCRIPTION
xdg-desktop-portal and xdg-desktop-portal-gtk were declared twice: at lines 162-163 (within the ChurrOS Desktop package group) and at lines 207-208 (near plymouth). The second set was redundant.\n\nRemoved the duplicate and verified no other duplicates remain with: sort packages.x86_64 | uniq -d