### PR TITLE
docs: actualizar stack del escritorio (greetd, foot, fuzzel)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,7 +52,7 @@ archiso/                      ArchISO profile root
   profiledef.sh               iso metadata, bootmodes, file_permissions map
   packages/                   Local pacman repo (built pkgs + repo db live here)
   airootfs/                   Squashfs root overlay
-    etc/skel/.config/          niri, waybar, kitty, fuzzel, starship — DO NOT MODIFY
+    etc/skel/.config/          niri, waybar, foot, fuzzel — DO NOT MODIFY
     root/scripts/             Live-ISO runtime scripts (users, services, desktop, cleanup, greetd-config)
     usr/share/churros/        Python GTK4/Libadwaita apps + scripts
 branding/                     Visual identity
@@ -88,8 +88,8 @@ Config files per instance: `shellprocess-pacman.conf`, `shellprocess-fixboot.con
 
 - **Live user**: `churros` (wheel, audio, video, input, storage, network), NOPASSWD sudo — created by `archiso/airootfs/root/scripts/users.sh`.
 - **Compositor**: Niri (Wayland scrollable-tiling). Requires 3D accel in QEMU (see Testing).
-- **Display Manager**: SDDM with autologin to `churros` / `niri` session.
-- **Panel/Launcher/Terminal**: Waybar / Fuzzel / Kitty.
+- **Display Manager**: greetd with autologin to `churros` / `niri` session.
+- **Panel/Launcher/Terminal**: Waybar / Fuzzel / foot.
 - **Apps**: Python GTK4 + Libadwaita in `archiso/airootfs/usr/share/churros/` (`churros-welcome`, `control-center`, `popups`, `preferences`, `services`), installed into `/usr/bin/churros-*` via `profiledef.sh` perms.
 - **Installer**: Calamares with custom `churros` branding (slideshow, QSS stylesheet).
 - **Boot modes** (from `profiledef.sh`): `bios.syslinux` + `uefi.systemd-boot`. No GRUB.
@@ -100,7 +100,7 @@ Config files per instance: `shellprocess-pacman.conf`, `shellprocess-fixboot.con
 
 - `installer/calamares/branding/churros/` — branding, slideshow, QSS.
 - `branding/` — colors, typography, logo guidelines, mascot.
-- `archiso/airootfs/etc/skel/.config/` — niri, waybar, kitty, fuzzel, starship themes.
+- `archiso/airootfs/etc/skel/.config/` — niri, waybar, foot, fuzzel themes.
 - Bootloader graphics and splash images.
 
 ## Notes

--- a/README.md
+++ b/README.md
@@ -157,8 +157,8 @@ Toda la documentación oficial se encuentra en la carpeta `docs/`.
 
 - Niri
 - Waybar
-- Kitty
-- Rofi
+- foot
+- Fuzzel
 - Temas
 
 ## Fase 4

--- a/docs/README.md
+++ b/docs/README.md
@@ -64,7 +64,7 @@ Cada documento aborda un aspecto específico del proyecto.
 | Popups | Sistema de popups (audio, battery, bluetooth, brightness, network, power). |
 | Preferences | App `churros-settings` — tema, accent, fuentes, cursor, wallpaper, power, etc. |
 | Services | Wrappers de servicios del sistema (wpctl, upower, nmcli, brightnessctl, etc). |
-| Desktop Config | Configuración del escritorio live (Niri, Waybar, SDDM, usuario). |
+| Desktop Config | Configuración del escritorio live (Niri, Waybar, greetd, usuario). |
 | Live Services | Servicios systemd y hooks del Live ISO. |
 | Boot | Sistema de arranque (GRUB, systemd-boot, Syslinux). |
 | VM | Máquina virtual de desarrollo con QEMU/KVM. |

--- a/docs/apps.md
+++ b/docs/apps.md
@@ -260,6 +260,5 @@ Para modificar una app:
 - Mover las apps a un repositorio separado: hoy viven dentro del repo de la distro. A largo plazo deberían empaquetarse e instalarse vía pacman.
 - Sustituir placeholders de las tarjetas de_action antiguas — hecho: hoy Welcome tiene Install/GitHub/Discord/Documentation/Terminal/Browser todas funcionales.
 - Internacionalización: hoy `i18n._()` (`/usr/share/churros/preferences/i18n.py` y la copia en `/usr/share/churros/i18n.py`) simplemente devuelve la string original; falta compilar `po/churros.po` a `/usr/share/locale/es/LC_MESSAGES/churros.mo`.
-- Migración foot → kitty: el AGENTS.md y README mencionan Kitty pero el sistema instala foot. Añadir `kitty` a `packages.x86_64` y cambiar spawns cuando se decida.
 - churros-ui: centralizar el CSS + widgets compartidos (hoy hay code duplication entre welcome/control-center/preferences/popups).
 - Tests: no hay suite de tests. Las apps interactúan con el sistema; verificación es `python3 -c "import ast; ast.parse(open(f).read())"` + lanzar manualmente cada app en niri.

--- a/docs/boot.md
+++ b/docs/boot.md
@@ -144,7 +144,7 @@ El proceso de arranque es el siguiente:
 4. El initramfs monta el sistema squashfs raíz.
 5. systemd arranca y los servicios live (ver `docs/live-services.md`) se inicializan.
 6. Si `accessibility=on` está presente, se activan los servicios de accesibilidad.
-7. SDDM arranca, autologin como `churros` y se carga Hyprland.
+7. greetd arranca, autologin como `churros` y se carga Niri.
 
 ---
 

--- a/docs/branding.md
+++ b/docs/branding.md
@@ -245,7 +245,7 @@ En futuras versiones incluirá:
 - Fastfetch personalizado.
 - Plymouth.
 - Tema de GRUB.
-- Tema de SDDM.
+- Tema / branding de greetd.
 - Wallpapers oficiales.
 - Iconos.
 - Cursor.

--- a/docs/desktop-config.md
+++ b/docs/desktop-config.md
@@ -1,6 +1,6 @@
 # Desktop Config
 
-Este documento describe la configuración del escritorio Live de ChurrOS: Niri, Waybar, SDDM y el usuario live.
+Este documento describe la configuración del escritorio Live de ChurrOS: Niri, Waybar, greetd y el usuario live.
 
 La configuración se aplica a todo usuario nuevo del sistema gracias a que vive en `/etc/skel/.config/`, que el script `desktop.sh` (ver `docs/live-services.md`) copia a `/home/churros/` durante la inicialización del Live.
 
@@ -108,13 +108,13 @@ layout {
 
 ```kdl
 spawn-at-startup "swaybg" "-i" "/usr/share/churros/wallpapers/default.jpeg" "-m" "fill"
+spawn-at-startup "churros-portal-start"
 spawn-at-startup "waybar"
 spawn-at-startup "mako"
-spawn-at-startup "awww-daemon"
 spawn-at-startup "churros-welcome"
 ```
 
-`swaybg` carga el wallpaper inicial. `waybar` arranca la barra superior. `mako` es el daemon de notificaciones. `awww-daemon` queda en background para futuros cambios de wallpaper vía preferences. `churros-welcome` muestra la pantalla de bienvenida.
+`swaybg` carga el wallpaper inicial y es el único gestor de wallpaper del autostart. `churros-portal-start` arranca los xdg-desktop-portals. `waybar` arranca la barra superior. `mako` es el daemon de notificaciones. `churros-welcome` muestra la pantalla de bienvenida.
 
 ---
 
@@ -200,22 +200,22 @@ Tipografía: `JetBrainsMono Nerd Font`, 14px en todo.
 
 ---
 
-# SDDM Autologin
+# greetd Autologin
 
-**Path:** `archiso/airootfs/etc/sddm.conf.d/autologin.conf`
+**Path:** `archiso/airootfs/etc/greetd/config.toml`
 
-```ini
-[Autologin]
-User=churros
-Session=niri
+```toml
+[terminal]
+vt = 1
 
-[General]
-InputMethod=
+[default_session]
+command = "/usr/bin/niri"
+user = "churros"
 ```
 
-SDDM arranca, autologin con el usuario `churros`, y carga la sesión `niri`. Esto permite que el Live entre directamente al escritorio sin pedir credenciales.
+greetd arranca en el VT1, autologin con el usuario `churros`, y lanza Niri directamente. Esto permite que el Live entre al escritorio sin pedir credenciales.
 
-El input method está vacío por defecto. Si añades soporte para otro idioma con caracteres especiales, edita esta línea.
+Tras la instalación, `greetd-config.sh` reescribe este archivo con el usuario creado por Calamares.
 
 ---
 
@@ -256,11 +256,11 @@ Durante el arranque del Live, los servicios y la configuración se aplican en es
 3. `.zlogin` ejecuta `/root/.automated_script.sh`.
 4. `customize_airootfs.sh` se ejecuta (ver `docs/live-services.md`):
    - Crea el usuario `churros` (`users.sh`)
-   - Habilita NetworkManager y SDDM (`services.sh`)
+   - Habilita NetworkManager y greetd (`services.sh`)
    - Copia la configuración de `/etc/skel/` a `/home/churros/` (`desktop.sh`)
    - Limpia la cache de pacman (`cleanup.sh`)
-5. SDDM arranca, autologin como `churros`, carga `niri`.
-6. Niri lee `config.kdl` y ejecuta los `spawn-at-startup` (awww-daemon, waybar, churros-welcome).
+5. greetd arranca, autologin como `churros`, carga `niri`.
+6. Niri lee `config.kdl` y ejecuta los `spawn-at-startup` (swaybg, waybar, churros-welcome, …).
 7. Waybar arranca y carga los popups de los módulos.
 
 ---
@@ -283,7 +283,7 @@ input {
 
 ## Cambiar el wallpaper
 
-Reemplaza `archiso/airootfs/usr/share/churros/wallpapers/default.jpeg` con tu imagen. `awww-daemon` la carga automáticamente al inicio.
+Reemplaza `archiso/airootfs/usr/share/churros/wallpapers/default.jpeg` con tu imagen. `swaybg` la carga automáticamente al inicio.
 
 ## Cambiar los gaps
 
@@ -318,5 +318,4 @@ En `config.jsonc`:
 - Soporte multi-monitor: configuración de outputs pendiente.
 - Perfiles de energía: cambiar decoraciones automáticamente según si el equipo está en batería. La infraestructura (PowerService + power-profile popup + battery subpágina) ya está lista.
 - Integración con `wlogout`: script de salida que se muestra desde el popup de power.
-- Migración de `foot` → `kitty`: docs mencionan Kitty pero el sistema instala foot. Añadir `kitty` a `packages.x86_64` y cambiar spawns de waybar/welcome/niri cuando se decida.
 - Traducciones reales (gettext): hoy `i18n._()` simplemente devuelve la string original (no carga PO files). Definir `po/churros.po` y compilar a `/usr/share/locale/es/LC_MESSAGES/churros.mo`.

--- a/docs/devlog.md
+++ b/docs/devlog.md
@@ -28,7 +28,7 @@ Sesión grande: terminadas las fases de personalización faltantes (5c, 5d), arr
 
 ### Config niri
 
-- Terminales mencionadas en docs (`AGENTS.md`, `README.md`, `docs/desktop-config.md`): Kitty. La realidad del repo: `foot` está en `packages.x86_64` (`kitty` no), `churros-welcome` lanza `foot`, waybar lanza `foot`, niri `Mod+Return` lanza `foot`. Decisión: se mantiene **foot** como terminal porque es la que está instalada; solo se documenta el gap para futura migración.
+- Terminal oficial: **foot** (`packages.x86_64`, welcome/waybar/niri `Mod+Return`). Las docs antiguas hablaban de Kitty; se corrigen para reflejar el stack real.
 - Terminal atajo: `Mod+Return` → foot (sin cambios).
 
 ### Waybar nuevos módulos

--- a/docs/goals.md
+++ b/docs/goals.md
@@ -7,7 +7,7 @@ Churros es una distribucion basada en Arch Linux enfocada en:
 - Simplicidad.
 - Alto rendimiento.
 - Diseno moderno.
-- Hyprland listo para usar.
+- Niri listo para usar.
 - Configuracion minima despues de instalar.
 
 ## Publico objetivo
@@ -20,11 +20,11 @@ Churros es una distribucion basada en Arch Linux enfocada en:
 ## Caracteristicas
 
 - Instalador grafico.
-- Hyprland por defecto.
+- Niri por defecto.
 - Quickshell.
 - Tema propio.
 - Wallpapers propios.
-- SDDM personalizado.
+- greetd con autologin.
 - Drivers automaticos.
 - Soporte para NVIDIA y AMD
 

--- a/docs/live-services.md
+++ b/docs/live-services.md
@@ -352,7 +352,7 @@ Resumen del orden de arranque del Live:
 6. `livecd-talk.service` (si `accessibility=on`) activa espeakup.
 7. `getty@tty1` hace autologin como root.
 8. `.zlogin` ejecuta `.automated_script.sh`.
-9. SDDM arranca.
+9. greetd arranca.
 10. Autologin como `churros`, sesión Niri.
 11. Niri carga autostart (waybar, swaybg, churros-welcome).
 
@@ -360,7 +360,7 @@ Resumen del orden de arranque del Live:
 
 # Future Work
 
-- Mover la lógica de `services.sh` (que habilita NetworkManager y SDDM) a unidades nativas de systemd.
+- Mover la lógica de `services.sh` (que habilita NetworkManager y greetd) a unidades nativas de systemd.
 - Eliminar la dependencia de root autologin: usar `systemd-user-sessions` o un PAM module.
 - Documentar el orden de dependencias entre servicios (hoy está implícito en los `After=` y `Before=`).
 - Internacionalizar los mensajes de los hooks.

--- a/docs/project-structure.md
+++ b/docs/project-structure.md
@@ -83,10 +83,10 @@ Ejemplos futuros:
 ```text
 configs
 ├── niri/
-├── kitty/
+├── foot/
 ├── waybar/
-├── rofi/
-└── sddm/
+├── fuzzel/
+└── greetd/
 ```
 
 La idea es mantener separadas las configuraciones del sistema y poder reutilizarlas fácilmente.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -45,7 +45,7 @@ Dar personalidad propia a la distribución.
 - [ ] Fastfetch personalizado.
 - [ ] Plymouth.
 - [ ] Tema de GRUB.
-- [ ] Tema de SDDM.
+- [ ] Tema / branding de greetd.
 - [ ] Iconos oficiales.
 - [ ] Cursor oficial.
 
@@ -57,10 +57,10 @@ Construir una experiencia de escritorio moderna.
 
 ## Objetivos
 
-- [ ] Hyprland configurado.
+- [ ] Niri configurado.
 - [ ] Waybar.
-- [ ] Kitty.
-- [ ] Rofi.
+- [ ] foot.
+- [ ] Fuzzel.
 - [ ] Wlogout.
 - [ ] Notificaciones.
 - [ ] Centro de control.


### PR DESCRIPTION
Parte de #5.

Las docs y AGENTS.md seguían hablando de SDDM, Kitty y Rofi (y a veces Hyprland). El código ya usa greetd, foot, fuzzel y Niri. Actualizo README, AGENTS.md y docs/* para que coincidan.

No toco el rename de contributin.md.