### PR TITLE
ci: comprobaciones estáticas con ./churros check y GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    name: Static checks
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install shellcheck and gettext
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y shellcheck gettext
+
+      - name: Run checks
+        run: ./churros check

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,6 +7,7 @@
 ./churros run        # Build (if needed) and launch QEMU
 ./churros run --nokvm  # Force software emulation (no /dev/kvm)
 ./churros clean      # Remove work/ and out/ (also runs sudo rm -rf)
+./churros check      # Static checks: bash, python, package list, niri autostart, po files
 ./churros doctor     # Check for mkarchiso, qemu, xorriso, mksquashfs, mcopy, mkinitcpio
 ./scripts/build-calamares.sh  # Build Calamares .pkg.tar.zst from AUR into archiso/packages/
 ./scripts/build-aur.sh        # Build python-pywal + waypaper + yay AUR packages
@@ -28,7 +29,11 @@ A trap on EXIT cleans generated files out of `archiso/airootfs/` (`root/customiz
 
 ## Testing
 
-There are no unit tests. Verification is via the QEMU live ISO:
+There are no unit tests yet. Two layers of verification exist today.
+
+`./churros check` runs the static checks (`scripts/cli/check.sh`): bash syntax, shellcheck at error level, Python syntax, duplicate entries in `packages.x86_64`, commands spawned by niri that resolve to a binary or package, and `msgfmt --check` on `po/*.po`. It needs no ISO build and runs in seconds. The same script runs in CI (`.github/workflows/ci.yml`) on every push to `main` and every pull request.
+
+Behaviour on the live system is verified in QEMU:
 
 ```bash
 ./churros run

--- a/churros
+++ b/churros
@@ -38,6 +38,7 @@ echo
 printf "  %-12s %s\n" "build"   "Build the ChurrOS ISO"
 printf "  %-12s %s\n" "run"     "Build (if needed) and launch QEMU"
 printf "  %-12s %s\n" "clean"   "Remove build artifacts"
+printf "  %-12s %s\n" "check"   "Run static checks over the repository"
 printf "  %-12s %s\n" "doctor"  "Check development environment"
 printf "  %-12s %s\n" "info"    "Display project information"
 printf "  %-12s %s\n" "version" "Display CLI version"
@@ -51,6 +52,7 @@ echo
 echo "  ./churros build"
 echo "  ./churros run"
 echo "  ./churros run --nokvm"
+echo "  ./churros check"
 echo "  ./churros doctor"
 echo
 }
@@ -69,6 +71,10 @@ run)
 
 clean)
     run_script clean
+    ;;
+
+check)
+    run_script check
     ;;
 
 doctor)

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -85,11 +85,39 @@ No elimina ningún archivo del código fuente.
 
 ---
 
+## check
+
+Ejecuta las comprobaciones estáticas del repositorio.
+
+```bash
+./churros check
+```
+
+Revisa:
+
+- Sintaxis de los scripts Bash y ShellCheck a nivel de error.
+- Sintaxis de todos los archivos Python.
+- Paquetes duplicados en `archiso/packages.x86_64`.
+- Que los comandos del autostart de Niri existan como binario o como paquete de la ISO.
+- Que los archivos de traducción `po/*.po` compilen.
+
+Termina con código 0 si todo pasa y 1 si algo falla. Los avisos de higiene del repositorio se informan pero no bloquean. No necesita construir la ISO ni permisos de root, y tarda unos segundos.
+
+Es el mismo comando que ejecuta el CI en cada Pull Request (ver `.github/workflows/ci.yml`).
+
+---
+
 # Flujo recomendado
 
 Durante el desarrollo se recomienda utilizar la siguiente secuencia:
 
 Modificar archivos
+
+↓
+
+```bash
+./churros check
+```
 
 ↓
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -89,12 +89,21 @@ Evita trabajar directamente sobre la rama principal cuando el proyecto tenga má
 
 Verifica siempre que:
 
+- Las comprobaciones automáticas pasan.
 - La ISO compila correctamente.
 - El sistema inicia sin errores.
 - La documentación está actualizada.
 - No existen archivos temporales innecesarios.
 
-Ejecuta:
+Ejecuta primero:
+
+```bash
+./churros check
+```
+
+Revisa la sintaxis de los scripts Bash y Python, los paquetes duplicados en `packages.x86_64`, que los comandos del autostart de Niri existan y que las traducciones compilen. Tarda unos segundos y no necesita construir la ISO. Es lo mismo que ejecuta el CI en cada Pull Request, así que si falla aquí, fallará allá.
+
+Si el cambio toca el escritorio, el instalador o el build:
 
 ```bash
 ./churros build

--- a/scripts/cli/check.sh
+++ b/scripts/cli/check.sh
@@ -1,0 +1,157 @@
+#!/usr/bin/env bash
+#
+# Static checks over the repository. Runs locally (./churros check) and in CI.
+# Exits 1 if any check fails. Hygiene notices are reported but never fail.
+
+# No -e here: every check must run so the report is complete.
+set -uo pipefail
+
+cd "$(dirname "$0")/../.." || exit 1
+
+FAILURES=0
+NOTICES=0
+
+section() { printf '\n== %s\n' "$1"; }
+pass()    { printf '  ✓ %s\n' "$1"; }
+fail()    { printf '  ✗ %s\n' "$1"; FAILURES=$((FAILURES + 1)); }
+notice()  { printf '  ! %s\n' "$1"; NOTICES=$((NOTICES + 1)); }
+
+mapfile -t SCRIPTS < <(git ls-files '*.sh' 'churros')
+
+# ------------------------------------------------------------- Bash syntax
+
+section "Bash syntax"
+
+syntax_errors=0
+for script in "${SCRIPTS[@]}"; do
+    if ! err=$(bash -n "$script" 2>&1); then
+        fail "$script: $err"
+        syntax_errors=$((syntax_errors + 1))
+    fi
+done
+[ "$syntax_errors" -eq 0 ] && pass "${#SCRIPTS[@]} scripts parse"
+
+# --------------------------------------------------------------- ShellCheck
+
+section "ShellCheck"
+
+if command -v shellcheck >/dev/null 2>&1; then
+    if shellcheck -S error "${SCRIPTS[@]}"; then
+        pass "no error-level findings"
+    else
+        fail "shellcheck reported errors"
+    fi
+    warnings=$(shellcheck -S warning -f gcc "${SCRIPTS[@]}" 2>/dev/null | grep -c warning)
+    [ "$warnings" -gt 0 ] && notice "$warnings style warnings (non-blocking)"
+else
+    notice "shellcheck not installed"
+fi
+
+# ----------------------------------------------------------- Python syntax
+
+section "Python syntax"
+
+# ast.parse only reads the source: it neither runs it nor writes .pyc files.
+if git ls-files '*.py' | python3 -c '
+import ast, sys
+
+files = [line.strip() for line in sys.stdin if line.strip()]
+broken = 0
+for path in files:
+    try:
+        ast.parse(open(path, encoding="utf-8").read(), filename=path)
+    except SyntaxError as exc:
+        print(f"    {path}:{exc.lineno}: {exc.msg}")
+        broken += 1
+print(f"    {len(files) - broken}/{len(files)} files parse")
+sys.exit(1 if broken else 0)
+'; then
+    pass "all Python files parse"
+else
+    fail "some Python files have syntax errors"
+fi
+
+# ---------------------------------------------------------- Package list
+
+section "ISO package list"
+
+duplicates=$(grep -v '^#' archiso/packages.x86_64 | grep -v '^$' | sort | uniq -d)
+if [ -n "$duplicates" ]; then
+    fail "duplicate entries in archiso/packages.x86_64:"
+    printf '      %s\n' $duplicates
+else
+    pass "no duplicates"
+fi
+
+# ------------------------------------------------------------ Niri autostart
+
+section "Commands referenced by Niri"
+
+NIRI_CONFIG=archiso/airootfs/etc/skel/.config/niri/config.kdl
+
+mapfile -t COMMANDS < <(
+    grep -oE '(spawn|spawn-at-startup) "[^"]+"' "$NIRI_CONFIG" |
+        sed -E 's/.*"([^"]+)"/\1/' | sort -u
+)
+
+mapfile -t PACKAGES < <(grep -v '^#' archiso/packages.x86_64 | grep -v '^$')
+
+# Binary names do not always match package names: awww-daemon ships in 'awww'
+# and plasma-discover in 'discover', so a substring match counts as a hit.
+command_exists() {
+    local command=$1 package
+    [ -e "archiso/airootfs/usr/bin/$command" ] && return 0
+    for package in "${PACKAGES[@]}"; do
+        [ "${#package}" -ge 4 ] || continue
+        [[ $command == *"$package"* ]] && return 0
+    done
+    return 1
+}
+
+missing=0
+for command in "${COMMANDS[@]}"; do
+    if ! command_exists "$command"; then
+        fail "'$command' is spawned by Niri but is neither in usr/bin nor in packages.x86_64"
+        missing=$((missing + 1))
+    fi
+done
+[ "$missing" -eq 0 ] && pass "${#COMMANDS[@]} commands resolve"
+
+# ------------------------------------------------------------ Translations
+
+section "Translations"
+
+if command -v msgfmt >/dev/null 2>&1; then
+    for po in po/*.po; do
+        [ -e "$po" ] || continue
+        if msgfmt --check -o /dev/null "$po" 2>/dev/null; then
+            pass "$po"
+        else
+            fail "$po has errors"
+        fi
+    done
+else
+    notice "msgfmt not available (gettext package)"
+fi
+
+# --------------------------------------------------------------- Hygiene
+
+section "Repository hygiene"
+
+tracked_artifacts=$(git ls-files | grep -cE '\.pyc$|\.pkg\.tar\.zst$|churros\.(db|files)|OVMF_VARS|^\.vscode/|^session-')
+if [ "$tracked_artifacts" -gt 0 ]; then
+    notice "$tracked_artifacts generated files are tracked in git"
+else
+    pass "no generated files tracked"
+fi
+
+# ---------------------------------------------------------------- Summary
+
+printf '\n----------------------------------------\n'
+if [ "$FAILURES" -eq 0 ]; then
+    printf 'All checks passed (%s notices)\n' "$NOTICES"
+    exit 0
+else
+    printf '%s checks failed (%s notices)\n' "$FAILURES" "$NOTICES"
+    exit 1
+fi


### PR DESCRIPTION
Parte de #18.

Añade `./churros check`, un comando que ejecuta las comprobaciones estáticas del repo, y un workflow que lo corre en cada push a `main` y en cada Pull Request.

Qué revisa:

- Sintaxis de todos los scripts Bash y ShellCheck a nivel de error.
- Sintaxis de los 142 archivos Python, con `ast.parse`, sin ejecutarlos ni generar `.pyc`.
- Paquetes duplicados en `archiso/packages.x86_64`.
- Que los comandos que Niri lanza con `spawn` / `spawn-at-startup` existan como binario en `airootfs/usr/bin` o como paquete de la ISO.
- Que `po/*.po` compilen con `msgfmt`.

Los artefactos generados que siguen versionados salen como aviso y no como fallo, para no dejar el CI en rojo mientras se decide qué hacer con ellos (#5).

Sobre el repo actual pasa todo. Probado también al revés: metiendo un duplicado en `packages.x86_64` el comando termina con código 1.

El script vive en `scripts/cli/check.sh` para que sea un subcomando más de la CLI, como pide `docs/cli.md`. Documentado ahí, en `docs/contributing.md` y en `AGENTS.md`.