### PR TITLE
ci: actualizar actions/checkout a v7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Install shellcheck and gettext
         run: |


### PR DESCRIPTION
Actualiza `actions/checkout` de v4 a v7 en el workflow de CI. v7 usa el runtime Node 24 y elimina el aviso de deprecación de Node.js 20.