### PR TITLE
docs: añadir política de seguridad

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,30 @@
+# Política de seguridad
+
+## Versiones soportadas
+
+ChurrOS está en etapa temprana de desarrollo. Solo se consideran reportes de seguridad contra la rama `main` y, cuando existan, las ISOs publicadas más recientes.
+
+## Cómo reportar una vulnerabilidad
+
+**No abrir un *issue* público** ni publicar detalles en canales abiertos (Discord, redes, etc.). Eso puede poner en riesgo a quien use la distro.
+
+Usar uno de estos canales **privados**, en este orden de preferencia:
+
+1. **[Advisory de seguridad privado en GitHub](https://github.com/Hoyuse/ChurrOS/security/advisories/new)** — opción recomendada cuando esté habilitada en el repositorio.
+2. **Mensaje privado a un administrador** en el [servidor de Discord de ChurrOS](https://discord.gg/4nAJbbzvd): entrar al servidor y contactar por DM a un admin/moderador indicando que se trata de un asunto de seguridad. No pegar detalles sensibles en canales públicos; el admin pedirá lo necesario por privado.
+3. **Mensaje privado a [@Hoyuse](https://github.com/Hoyuse)** en GitHub.
+
+Incluir, en la medida de lo posible:
+
+- Descripción del problema y su impacto.
+- Pasos para reproducirlo o una prueba de concepto.
+- Versión / commit / ISO afectada.
+- Cualquier mitigación conocida.
+
+## Qué esperar
+
+- Acuse de recibo cuando sea posible.
+- Evaluación del reporte y, si procede, un arreglo o mitigación en privado antes de divulgarlo.
+- Crédito al reportero si lo desea, una vez publicada la corrección.
+
+Los reportes de denegación de servicio triviales, *phishing* genérico o problemas ya documentados pueden descartarse sin seguimiento detallado.


### PR DESCRIPTION
Define cómo reportar vulnerabilidades: advisory privado de GitHub, DM a un admin en Discord, o mensaje privado a @Hoyuse. Sin issues públicos.