### PR TITLE
docs: añadir plantillas de issue

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,63 @@
+name: Informe de error
+description: Algo no funciona como debería en ChurrOS.
+title: "fix: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Gracias por el reporte. Cuanta más información, más fácil reproducir y arreglar.
+  - type: textarea
+    id: description
+    attributes:
+      label: Descripción
+      description: Qué ocurre y por qué es un problema.
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Pasos para reproducir
+      description: Lista numerada, lo más concreta posible.
+      placeholder: |
+        1.
+        2.
+        3.
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Resultado esperado
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Resultado obtenido
+    validations:
+      required: true
+  - type: dropdown
+    id: environment
+    attributes:
+      label: Entorno
+      options:
+        - ISO live (QEMU / máquina virtual)
+        - ISO live (hardware)
+        - Sistema instalado
+        - Solo host de desarrollo (scripts / docs)
+        - Otro
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: Versión o commit
+      description: Contenido de `VERSION`, etiqueta de release o hash de commit si se conoce.
+      placeholder: "p. ej. 0.1.0 o ecd4adc"
+  - type: textarea
+    id: logs
+    attributes:
+      label: Registros o capturas
+      description: Salida relevante de terminal, `vm_serial.log`, capturas, etc.
+      render: shell

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Documentación
+    url: https://github.com/Hoyuse/ChurrOS/tree/main/docs
+    about: Guías del proyecto (build, escritorio, contribución, etc.).
+  - name: Discord de ChurrOS
+    url: https://discord.gg/4nAJbbzvd
+    about: Comunidad y contacto con administradores (para seguridad, usar DM privado).
+  - name: Reportar una vulnerabilidad
+    url: https://github.com/Hoyuse/ChurrOS/security/advisories/new
+    about: No uses issues públicos. Preferir advisory privado o DM a un admin en Discord.

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,0 +1,33 @@
+name: Propuesta de mejora
+description: Idea o cambio de comportamiento para discutir antes de implementar.
+title: "feat: "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Para cambios grandes, conviene discutirlos aquí antes de abrir un PR.
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problema o necesidad
+      description: Qué falta o qué se quiere mejorar.
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Propuesta
+      description: Cómo se imagina la solución (a alto nivel).
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternativas consideradas
+      description: Otras opciones o por qué esta es preferible.
+  - type: textarea
+    id: context
+    attributes:
+      label: Contexto adicional
+      description: Enlaces, capturas, issues relacionados, etc.


### PR DESCRIPTION
Añade plantillas de error y mejora, más enlaces de contacto (docs, Discord, advisory de seguridad).