### PR TITLE
fix: reenviar flags de la CLI y unificar el dispatcher

### DIFF
--- a/churros
+++ b/churros
@@ -1,13 +1,21 @@
 #!/usr/bin/env bash
 
-set -e
-
-show_logo() {
-    "$SCRIPTS_DIR/logo.sh"
-}
+set -euo pipefail
 
 CLI_DIR="$(cd "$(dirname "$0")" && pwd)"
 SCRIPTS_DIR="$CLI_DIR/scripts/cli"
+
+# Explicit public surface. Extra files in scripts/cli/ are not commands.
+PUBLIC_COMMANDS=(
+    build
+    run
+    clean
+    check
+    doctor
+    info
+    version
+    logo
+)
 
 run_script() {
     local name="$1"
@@ -20,89 +28,76 @@ run_script() {
     bash "$script" "$@"
 }
 
+is_public_command() {
+    local needle="$1"
+    local cmd
+    for cmd in "${PUBLIC_COMMANDS[@]}"; do
+        if [ "$cmd" = "$needle" ]; then
+            return 0
+        fi
+    done
+    return 1
+}
+
+show_logo() {
+    "$SCRIPTS_DIR/logo.sh"
+}
+
 show_help() {
+    show_logo
 
-show_logo
+    echo "ChurrOS Development CLI"
+    echo "Version $(cat "$CLI_DIR/VERSION")"
+    echo
 
-echo "ChurrOS Development CLI"
-echo "Version $(cat "$CLI_DIR/VERSION")"
-echo
+    echo "Usage:"
+    echo "  ./churros <command> [options]"
+    echo
 
-echo "Usage:"
-echo "  ./churros <command>"
-echo
+    echo "Available commands:"
+    echo
 
-echo "Available commands:"
-echo
+    printf "  %-12s %s\n" "build"   "Build the ChurrOS ISO"
+    printf "  %-12s %s\n" "run"     "Build (if needed) and launch QEMU"
+    printf "  %-12s %s\n" "clean"   "Remove build artifacts"
+    printf "  %-12s %s\n" "check"   "Run static checks over the repository"
+    printf "  %-12s %s\n" "doctor"  "Check development environment"
+    printf "  %-12s %s\n" "info"    "Display project information"
+    printf "  %-12s %s\n" "version" "Display CLI version"
+    printf "  %-12s %s\n" "logo"    "Print ChurrOS logo"
 
-printf "  %-12s %s\n" "build"   "Build the ChurrOS ISO"
-printf "  %-12s %s\n" "run"     "Build (if needed) and launch QEMU"
-printf "  %-12s %s\n" "clean"   "Remove build artifacts"
-printf "  %-12s %s\n" "check"   "Run static checks over the repository"
-printf "  %-12s %s\n" "doctor"  "Check development environment"
-printf "  %-12s %s\n" "info"    "Display project information"
-printf "  %-12s %s\n" "version" "Display CLI version"
-printf "  %-12s %s\n" "logo"    "Print ChurrOS logo"
+    echo
 
-echo
+    echo "Examples:"
+    echo
 
-echo "Examples:"
-echo
-
-echo "  ./churros build"
-echo "  ./churros run"
-echo "  ./churros run --nokvm"
-echo "  ./churros run --fresh"
-echo "  ./churros check"
-echo "  ./churros doctor"
-echo
+    echo "  ./churros build"
+    echo "  ./churros run"
+    echo "  ./churros run --nokvm"
+    echo "  ./churros run --fresh"
+    echo "  ./churros run --clean"
+    echo "  ./churros check"
+    echo "  ./churros doctor"
+    echo
 }
 
 cd "$CLI_DIR"
 
-case "$1" in
+command="${1-}"
 
-build)
-    run_script build
-    ;;
-
-run)
-    run_script run
-    ;;
-
-clean)
-    run_script clean
-    ;;
-
-check)
-    run_script check
-    ;;
-
-doctor)
-    run_script doctor
-    ;;
-
-info)
-    run_script info
-    ;;
-
-version)
-    run_script version
-    ;;
-
-logo)
-    run_script logo
-    ;;
-
-""|-h|--help|help)
-    show_help
-    ;;
-
-*)
-    echo
-    echo "Unknown command: $1"
-    echo
-    show_help
-    exit 1
-    ;;
+case "$command" in
+    ""|-h|--help|help)
+        show_help
+        ;;
+    *)
+        if is_public_command "$command"; then
+            run_script "$@"
+        else
+            echo
+            echo "Unknown command: $command"
+            echo
+            show_help
+            exit 1
+        fi
+        ;;
 esac

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -23,14 +23,17 @@ En lugar de recordar comandos largos de ArchISO o QEMU, todo se centraliza en:
 # Uso
 
 ```bash
-./churros <comando>
+./churros <comando> [opciones]
 ```
 
 Ejemplo:
 
 ```bash
 ./churros build
+./churros run --fresh
 ```
+
+Los argumentos posteriores al subcomando se reenvían al script `scripts/cli/<comando>.sh`. Un archivo `.sh` en ese directorio no es un comando público hasta que se añade a la lista explícita del dispatcher `churros`.
 
 ---
 
@@ -60,9 +63,18 @@ Construye la ISO (si es necesario) y la inicia en una máquina virtual utilizand
 
 ```bash
 ./churros run
+./churros run --nokvm
+./churros run --fresh
+./churros run --clean
 ```
 
 Este comando permite probar rápidamente los cambios realizados sin necesidad de crear una máquina virtual manualmente.
+
+Flags opcionales (detalle en `docs/vm.md`):
+
+- `--nokvm` — emulación por software, sin KVM.
+- `--fresh` — resetea `vm/OVMF_VARS.fd` para arrancar desde el CD-ROM.
+- `--clean` — borra el disco de la VM y las variables EFI antes de arrancar.
 
 ---
 
@@ -104,6 +116,46 @@ Revisa:
 Termina con código 0 si todo pasa y 1 si algo falla. Los avisos de higiene del repositorio se informan pero no bloquean. No necesita construir la ISO ni permisos de root, y tarda unos segundos.
 
 Es el mismo comando que ejecuta el CI en cada Pull Request (ver `.github/workflows/ci.yml`).
+
+---
+
+## doctor
+
+Comprueba que las herramientas del entorno de desarrollo estén instaladas (`mkarchiso`, `qemu-system-x86_64`, `xorriso`, etc.).
+
+```bash
+./churros doctor
+```
+
+---
+
+## info
+
+Muestra información del proyecto y del entorno (versión, rama, arquitectura y directorios).
+
+```bash
+./churros info
+```
+
+---
+
+## version
+
+Muestra la versión actual de la CLI.
+
+```bash
+./churros version
+```
+
+---
+
+## logo
+
+Muestra el logotipo oficial de ChurrOS en la terminal.
+
+```bash
+./churros logo
+```
 
 ---
 
@@ -149,7 +201,7 @@ Push
 
 La CLI está diseñada para crecer junto con el proyecto.
 
-Cada nueva funcionalidad de desarrollo debe añadirse como un nuevo comando.
+Cada nueva funcionalidad de desarrollo debe añadirse como un nuevo comando: un script `scripts/cli/<comando>.sh` y una entrada en la lista explícita de comandos públicos del dispatcher `churros`. Un `.sh` extra en ese directorio no queda expuesto solo por existir.
 
 Esto evita depender de múltiples scripts independientes.
 
@@ -158,21 +210,6 @@ Esto evita depender de múltiples scripts independientes.
 # Comandos planificados
 
 Las siguientes funciones están previstas para futuras versiones.
-
-## doctor
-
-```bash
-./churros doctor
-```
-
-Verificará automáticamente:
-
-- Dependencias instaladas.
-- Estado del entorno.
-- Versiones requeridas.
-- Configuración de virtualización.
-
----
 
 ## release
 
@@ -218,26 +255,6 @@ Actualizará las dependencias del proyecto.
 ```
 
 Abrirá la documentación oficial.
-
----
-
-## version
-
-```bash
-./churros version
-```
-
-Mostrará la versión actual del proyecto.
-
----
-
-## logo
-
-```bash
-./churros logo
-```
-
-Mostrará el logotipo oficial de ChurrOS en la terminal.
 
 ---
 

--- a/docs/vm.md
+++ b/docs/vm.md
@@ -27,6 +27,7 @@ Flags opcionales:
 |------|-------------|
 | `--nokvm` | Desactiva KVM y emula por software (CPU de 2 hilos, q35 sin `accel`). |
 | `--fresh` | Borra `vm/OVMF_VARS.fd` antes de arrancar para que OVMF parta limpio y arranque desde el CD-ROM en vez del disco. Útil tras instalar ChurrOS en la VM y necesitar probar de nuevo la ISO live. |
+| `--clean` | Borra `vm/ChurrOS.qcow2` y `vm/OVMF_VARS.fd` antes de arrancar (disco + variables EFI). |
 
 > **Consejo:** Si acabas de instalar ChurrOS en la VM, OVMF guarda la entrada `Boot0009 "ChurrOS"` en `OVMF_VARS.fd`, así que el siguiente arranque dirá `BdsDxe: starting Boot0009 "ChurrOS"` y entrará al sistema instalado. Ejecuta `./churros run --fresh` para arrancar limpio del CD-ROM, o simplemente `rm vm/OVMF_VARS.fd`.
 


### PR DESCRIPTION
El dispatcher invocaba cada subcomando sin `"$@"`, así que `./churros run --fresh`, `--nokvm` y `--clean` no llegaban a `run.sh`.

Los comandos públicos quedan en una lista explícita (`PUBLIC_COMMANDS`) y se ejecutan de forma genérica. Un `.sh` extra en `scripts/cli/` no se expone solo por existir.

`docs/cli.md` describe el comportamiento real: reenvío de argumentos, flags de `run`, y `doctor` / `info` / `version` / `logo` como comandos disponibles.