### PR TITLE
test: parser JSONC de Waybar y job de cargo test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,3 +23,15 @@ jobs:
 
       - name: Run checks
         run: ./churros check
+
+  test:
+    name: Tests Rust
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - name: cargo test -p churros-services
+        run: cargo test -p churros-services --manifest-path rust/Cargo.toml

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -76,6 +76,7 @@ dependencies = [
 name = "churros-services"
 version = "0.1.0"
 dependencies = [
+ "serde_json",
  "wait-timeout",
 ]
 
@@ -83,6 +84,7 @@ dependencies = [
 name = "churros-settings"
 version = "0.1.0"
 dependencies = [
+ "churros-services",
  "gio",
  "glib",
  "gtk4",

--- a/rust/preferences/Cargo.toml
+++ b/rust/preferences/Cargo.toml
@@ -10,6 +10,7 @@ deploy = true
 
 [dependencies]
 adw = { version = "0.9.2", package = "libadwaita" }
+churros-services = { path = "../services" }
 gio = "0.22.8"
 glib = "0.22.8"
 gtk = { version = "0.11.4", package = "gtk4", features = ["v4_22"] }

--- a/rust/preferences/src/services/waybar.rs
+++ b/rust/preferences/src/services/waybar.rs
@@ -44,81 +44,15 @@ pub fn defaults() -> Value {
     })
 }
 
-/// Lee un JSONC (comentarios // + trailing commas) y devuelve el objeto.
-fn read_jsonc(path: &PathBuf) -> Value {
+/// Lee un JSONC. `None` = el archivo existe pero no se pudo leer o parsear.
+/// `Some({})` = no hay archivo todavía (primera vez). Nunca se finge un
+/// objeto vacío cuando el parseo falla: eso podía borrar la config al guardar.
+fn read_jsonc(path: &PathBuf) -> Option<Value> {
     if !path.exists() {
-        return json!({});
+        return Some(json!({}));
     }
-    let Ok(raw) = fs::read_to_string(path) else {
-        return json!({});
-    };
-
-    // Quitar comentarios // (fuera de strings)
-    let mut cleaned = String::with_capacity(raw.len());
-    let mut in_string = false;
-    let mut in_comment = false;
-    let mut escape = false;
-
-    for ch in raw.chars() {
-        if in_comment {
-            if ch == '\n' {
-                in_comment = false;
-                cleaned.push('\n');
-            }
-            continue;
-        }
-        if in_string {
-            cleaned.push(ch);
-            if escape {
-                escape = false;
-                continue;
-            }
-            if ch == '\\' {
-                escape = true;
-                continue;
-            }
-            if ch == '"' {
-                in_string = false;
-            }
-            continue;
-        }
-        if ch == '/' && cleaned.ends_with('/') {
-            cleaned.pop();
-            in_comment = true;
-            continue;
-        }
-        if ch == '"' {
-            in_string = true;
-        }
-        cleaned.push(ch);
-    }
-
-    // Eliminar trailing commas: ,} -> } y ,] -> ]
-    let text = remove_trailing_commas(&cleaned);
-
-    serde_json::from_str(&text).unwrap_or_else(|_| json!({}))
-}
-
-fn remove_trailing_commas(text: &str) -> String {
-    let chars: Vec<char> = text.chars().collect();
-    let mut out = String::with_capacity(text.len());
-    let mut i = 0;
-    while i < chars.len() {
-        let c = chars[i];
-        if c == ',' {
-            let mut j = i + 1;
-            while j < chars.len() && (chars[j] == ' ' || chars[j] == '\t' || chars[j] == '\n' || chars[j] == '\r') {
-                j += 1;
-            }
-            if j < chars.len() && (chars[j] == '}' || chars[j] == ']') {
-                i += 1;
-                continue;
-            }
-        }
-        out.push(c);
-        i += 1;
-    }
-    out
+    let raw = fs::read_to_string(path).ok()?;
+    churros_services::jsonc::parse(&raw).ok()
 }
 
 fn write_jsonc(path: &PathBuf, data: &Value) {
@@ -470,7 +404,7 @@ impl WaybarService {
 
     /// Lee config.jsonc + colors-waybar.css y devuelve el estado completo.
     pub fn get() -> Value {
-        let cfg = read_jsonc(&config_path());
+        let cfg = read_jsonc(&config_path()).unwrap_or_else(|| json!({}));
         let colors = read_colors();
 
         let d = defaults();
@@ -496,7 +430,10 @@ impl WaybarService {
     /// hace que waybar desaparezca temporalmente y en algunas builds la mata).
     pub fn set(values: &Value) {
         let d = defaults();
-        let mut cfg = read_jsonc(&config_path());
+        let Some(mut cfg) = read_jsonc(&config_path()) else {
+            eprintln!("[waybar] config.jsonc ilegible; no se sobrescribe");
+            return;
+        };
 
         cfg["layer"] = values
             .get("layer")

--- a/rust/services/Cargo.toml
+++ b/rust/services/Cargo.toml
@@ -13,4 +13,5 @@ name = "churros_services"
 deploy = false
 
 [dependencies]
+serde_json = "1"
 wait-timeout = "0.2"

--- a/rust/services/src/jsonc.rs
+++ b/rust/services/src/jsonc.rs
@@ -1,0 +1,166 @@
+// Parser JSONC mínimo: comentarios // fuera de strings + trailing commas.
+// Extraído de WaybarService para poder testearlo sin GTK ni $HOME.
+
+use serde_json::Value;
+
+/// El texto no es JSON válido después de quitar comentarios y comas finales.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct JsoncError(pub String);
+
+/// Quita comentarios `//` que no estén dentro de un string.
+pub fn strip_line_comments(raw: &str) -> String {
+    let mut cleaned = String::with_capacity(raw.len());
+    let mut in_string = false;
+    let mut in_comment = false;
+    let mut escape = false;
+
+    for ch in raw.chars() {
+        if in_comment {
+            if ch == '\n' {
+                in_comment = false;
+                cleaned.push('\n');
+            }
+            continue;
+        }
+        if in_string {
+            cleaned.push(ch);
+            if escape {
+                escape = false;
+                continue;
+            }
+            if ch == '\\' {
+                escape = true;
+                continue;
+            }
+            if ch == '"' {
+                in_string = false;
+            }
+            continue;
+        }
+        if ch == '/' && cleaned.ends_with('/') {
+            cleaned.pop();
+            in_comment = true;
+            continue;
+        }
+        if ch == '"' {
+            in_string = true;
+        }
+        cleaned.push(ch);
+    }
+
+    cleaned
+}
+
+/// Elimina comas finales: `,}` → `}` y `,]` → `]`.
+pub fn remove_trailing_commas(text: &str) -> String {
+    let chars: Vec<char> = text.chars().collect();
+    let mut out = String::with_capacity(text.len());
+    let mut i = 0;
+    while i < chars.len() {
+        let c = chars[i];
+        if c == ',' {
+            let mut j = i + 1;
+            while j < chars.len()
+                && (chars[j] == ' ' || chars[j] == '\t' || chars[j] == '\n' || chars[j] == '\r')
+            {
+                j += 1;
+            }
+            if j < chars.len() && (chars[j] == '}' || chars[j] == ']') {
+                i += 1;
+                continue;
+            }
+        }
+        out.push(c);
+        i += 1;
+    }
+    out
+}
+
+/// Parsea JSONC. Si el texto no es válido, devuelve error (nunca un `{}` silencioso).
+pub fn parse(text: &str) -> Result<Value, JsoncError> {
+    let stripped = strip_line_comments(text);
+    let cleaned = remove_trailing_commas(&stripped);
+    serde_json::from_str(&cleaned).map_err(|err| JsoncError(err.to_string()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn plain_json() {
+        let value = parse(r#"{"position":"top","height":30}"#).unwrap();
+        assert_eq!(value["position"], "top");
+        assert_eq!(value["height"], 30);
+    }
+
+    #[test]
+    fn strips_line_comments() {
+        let raw = r#"
+        {
+            // barra arriba
+            "position": "top",
+            "height": 30 // px
+        }
+        "#;
+        let value = parse(raw).unwrap();
+        assert_eq!(value["position"], "top");
+        assert_eq!(value["height"], 30);
+    }
+
+    #[test]
+    fn keeps_slashes_inside_strings() {
+        let value = parse(r#"{"url":"https://churros.local","note":"usa // así"}"#).unwrap();
+        assert_eq!(value["url"], "https://churros.local");
+        assert_eq!(value["note"], "usa // así");
+    }
+
+    #[test]
+    fn keeps_escaped_quotes_inside_strings() {
+        let value = parse(r#"{"label":"di \"hola\""}"#).unwrap();
+        assert_eq!(value["label"], r#"di "hola""#);
+    }
+
+    #[test]
+    fn removes_trailing_commas() {
+        let raw = r#"
+        {
+            "modules": ["clock", "battery",],
+            "nested": { "a": 1, },
+        }
+        "#;
+        let value = parse(raw).unwrap();
+        assert_eq!(value["modules"], json!(["clock", "battery"]));
+        assert_eq!(value["nested"]["a"], 1);
+    }
+
+    #[test]
+    fn invalid_json_is_error_not_empty_object() {
+        // El fallo que #18 quería pillar: un parse roto no puede parecer un archivo vacío.
+        assert!(parse("{ esto no es json").is_err());
+    }
+
+    #[test]
+    fn empty_object_is_valid() {
+        assert_eq!(parse("{}").unwrap(), json!({}));
+    }
+
+    #[test]
+    fn parses_skel_waybar_config() {
+        let path = concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../archiso/airootfs/etc/skel/.config/waybar/config.jsonc"
+        );
+        let raw = std::fs::read_to_string(path)
+            .unwrap_or_else(|err| panic!("no se pudo leer {path}: {err}"));
+        let value = parse(&raw).expect("el config.jsonc del skel tiene que parsear");
+        assert_eq!(value["position"], "top");
+        assert_eq!(value["layer"], "top");
+        let right = value["modules-right"]
+            .as_array()
+            .expect("modules-right es una lista");
+        assert!(right.iter().any(|m| m == "clock"));
+        assert!(value.get("niri/workspaces").is_some());
+    }
+}

--- a/rust/services/src/lib.rs
+++ b/rust/services/src/lib.rs
@@ -8,6 +8,7 @@ pub mod battery;
 pub mod bluetooth;
 pub mod brightness;
 pub mod ethernet;
+pub mod jsonc;
 pub mod power;
 pub mod wifi;
 


### PR DESCRIPTION
## Resumen
- El lector JSONC de Waybar pasa a `churros-services`, con tests de comentarios, comas finales y el `config.jsonc` del skel.
- Si el archivo no parsea, Preferencias ya no finge que está vacío al guardar.
- El CI corre `cargo test -p churros-services` en un job aparte.

Parte de #18

## Cómo probar
- [ ] `cargo test -p churros-services --manifest-path rust/Cargo.toml`
- [ ] `./churros check`
- [ ] El job «Tests Rust» del CI en verde