### PR TITLE
docs: corregir estructura, boot y flujo de build

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -14,7 +14,15 @@ Cada directorio tiene una única responsabilidad.
 archiso/
 ```
 
-Contiene el perfil de ArchISO utilizado para generar la imagen.
+Perfil de ArchISO: paquetes, airootfs, cargadores de la ISO.
+
+---
+
+```
+rust/
+```
+
+Apps oficiales (gtk4-rs + libadwaita) y la librería `churros_services`. Los binarios se despliegan en el airootfs al construir.
 
 ---
 
@@ -22,13 +30,19 @@ Contiene el perfil de ArchISO utilizado para generar la imagen.
 branding/
 ```
 
-Contiene toda la identidad visual del proyecto.
+Identidad visual y `customize_airootfs.sh` (se copia al Live en cada build).
 
-- Logos
-- Wallpapers
-- Iconos
-- Colores
-- Tipografía
+- Archivos de sistema (`os-release`, issue, motd)
+- Tema GRUB
+- Guías de color, tipografía, logo y mascota
+
+---
+
+```
+installer/
+```
+
+Configuración de Calamares (`settings.conf`, módulos, `apply-calamares.sh`).
 
 ---
 
@@ -44,17 +58,31 @@ Documentación oficial.
 scripts/
 ```
 
-Scripts auxiliares.
-
-Nunca deberán contener recursos del sistema.
+CLI (`./churros`) y scripts de build. Nunca deberán contener recursos del sistema instalado.
 
 ---
 
 ```
-installer/
+po/
 ```
 
-Código del futuro instalador gráfico.
+Traducciones gettext.
+
+---
+
+# Stack del escritorio
+
+| Pieza | Implementación |
+|-------|----------------|
+| Compositor | Niri |
+| Display manager | greetd (autologin en Live) |
+| Terminal | foot |
+| Launcher | Fuzzel |
+| Panel | Waybar |
+| Notificaciones | Mako |
+| Audio | PipeWire + WirePlumber |
+| Instalador | Calamares |
+| Arranque ISO | GRUB (UEFI) + Syslinux (BIOS) |
 
 ---
 
@@ -75,7 +103,7 @@ Esto facilita:
 
 La arquitectura podrá cambiar cuando sea necesario.
 
-Sin embargo, cualquier modificación importante deberá mantener la simplicidad del proyecto.
+Cualquier modificación importante deberá mantener la simplicidad del proyecto.
 
 ---
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -60,13 +60,13 @@ Cada documento aborda un aspecto específico del proyecto.
 | Branding | Personalización e identidad de ChurrOS. |
 | CLI | Herramienta de desarrollo `./churros`. |
 | Development | Flujo de trabajo recomendado para desarrollar ChurrOS. |
-| Apps | Apps oficiales GTK4 (welcome, control-center, settings, fuzzel). |
+| Apps | Apps oficiales GTK4 en Rust (welcome, control-center, settings, popups). |
 | Popups | Sistema de popups (audio, battery, bluetooth, brightness, network, power). |
 | Preferences | App `churros-settings` — tema, accent, fuentes, cursor, wallpaper, power, etc. |
 | Services | Wrappers de servicios del sistema (wpctl, upower, nmcli, brightnessctl, etc). |
 | Desktop Config | Configuración del escritorio live (Niri, Waybar, greetd, usuario). |
 | Live Services | Servicios systemd y hooks del Live ISO. |
-| Boot | Sistema de arranque (GRUB, systemd-boot, Syslinux). |
+| Boot | Sistema de arranque (GRUB UEFI + Syslinux BIOS). |
 | VM | Máquina virtual de desarrollo con QEMU/KVM. |
 | Release | Proceso para generar una versión oficial. |
 | Roadmap | Estado actual y objetivos futuros del proyecto. |

--- a/docs/branding.md
+++ b/docs/branding.md
@@ -36,17 +36,21 @@ Todo el branding se encuentra dentro del directorio:
 branding/
 ```
 
-La estructura recomendada es:
+La estructura actual es:
 
 ```text
 branding
-├── files/
-├── logos/
-├── wallpapers/
-├── fastfetch/
-├── plymouth/
-└── installer/
+├── customize_airootfs.sh
+├── files/              # os-release, issue, motd
+├── grub-theme/         # tema del GRUB instalado
+├── colors.md
+├── typography.md
+├── logo-guidelines.md
+├── mascot.md
+└── ui-guidelines.md
 ```
+
+Los wallpapers, logos de escritorio y Fastfetch viven en `archiso/airootfs/usr/share/churros/`. Plymouth y un tema propio de greetd aún no están. El branding de Calamares está en `installer/calamares/branding/churros/` (no se edita salvo que el cambio lo pida).
 
 ---
 
@@ -136,50 +140,27 @@ Debe contener la identidad oficial de ChurrOS.
 
 # Logos
 
-La carpeta:
-
-```text
-branding/logos/
-```
-
-almacenará los logotipos oficiales de la distribución.
-
-Versiones recomendadas:
-
-- SVG
-- PNG
-- Blanco
-- Negro
-- Monocromático
+Las guías están en `branding/logo-guidelines.md`. Los SVG/PNG que usa el escritorio viven en `archiso/airootfs/usr/share/churros/` (welcome, control-center, etc.).
 
 ---
 
 # Wallpapers
 
-Todos los fondos oficiales deberán almacenarse en:
+Los fondos oficiales están en:
 
 ```text
-branding/wallpapers/
+archiso/airootfs/usr/share/churros/wallpapers/
 ```
-
-Esto permitirá reutilizarlos durante la instalación del sistema.
 
 ---
 
 # Fastfetch
 
-Las configuraciones oficiales de Fastfetch vivirán en:
+La config live está en:
 
 ```text
-branding/fastfetch/
+archiso/airootfs/usr/share/churros/defaults/fastfetch/
 ```
-
-Aquí se definirán:
-
-- logo
-- colores
-- información mostrada
-- formato
 
 ---
 
@@ -197,18 +178,7 @@ Permitirá personalizar completamente la animación de arranque.
 
 # Instalador
 
-Los recursos gráficos del instalador gráfico vivirán en:
-
-```text
-branding/installer/
-```
-
-Por ejemplo:
-
-- iconos
-- ilustraciones
-- fondos
-- logotipo
+El branding de Calamares está en `installer/calamares/branding/churros/` (slideshow, QSS). No se toca salvo que el cambio lo pida explícitamente.
 
 ---
 
@@ -228,11 +198,9 @@ Este script reemplaza los archivos originales del sistema por los personalizados
 
 # Buenas prácticas
 
-Se recomienda mantener todos los recursos gráficos centralizados dentro de la carpeta branding.
+Las guías y el script live viven en `branding/`. Los assets que el escritorio carga en runtime viven en `archiso/airootfs/usr/share/churros/`.
 
-No almacenar imágenes o logotipos dentro de otros directorios del proyecto.
-
-Esto facilita el mantenimiento y futuras modificaciones de la identidad visual.
+No mezclar scripts de build con recursos gráficos. No editar las copias generadas en el airootfs (`root/customize_airootfs.sh`, `root/branding/`).
 
 ---
 
@@ -240,16 +208,12 @@ Esto facilita el mantenimiento y futuras modificaciones de la identidad visual.
 
 El sistema de branding evolucionará para abarcar toda la experiencia del usuario.
 
-En futuras versiones incluirá:
+Ya cubre Fastfetch, wallpapers, iconos, cursor, tema GRUB e instalador Calamares.
 
-- Fastfetch personalizado.
+Sigue pendiente:
+
 - Plymouth.
-- Tema de GRUB.
 - Tema / branding de greetd.
-- Wallpapers oficiales.
-- Iconos.
-- Cursor.
 - Sonidos del sistema.
-- Instalador gráfico.
 
-El objetivo final es que toda la experiencia visual de ChurrOS sea consistente desde el arranque hasta el escritorio.
+El objetivo es que la experiencia visual sea consistente desde el arranque hasta el escritorio.

--- a/docs/build-system.md
+++ b/docs/build-system.md
@@ -1,14 +1,12 @@
 # Build System
 
-El sistema de compilación de ChurrOS está basado en **ArchISO** y automatizado mediante la herramienta de desarrollo `./churros`.
+El sistema de compilación de ChurrOS está basado en **ArchISO** y automatizado mediante `./churros`.
 
-El objetivo del sistema de compilación es generar imágenes ISO reproducibles, mantener un flujo de trabajo sencillo y minimizar las tareas manuales.
+El objetivo es generar imágenes ISO reproducibles, mantener un flujo sencillo y minimizar las tareas manuales.
 
 ---
 
 # Arquitectura
-
-El proceso de compilación puede resumirse de la siguiente manera:
 
 ```
                Código fuente
@@ -16,15 +14,13 @@ El proceso de compilación puede resumirse de la siguiente manera:
                      ▼
               ./churros build
                      │
+        ┌────────────┼────────────┐
+        ▼            ▼            ▼
+    branding    paquetes AUR   apps Rust
+        │            │            │
+        └────────────┼────────────┘
                      ▼
-          Preparación del entorno
-                     │
-                     ▼
-              Ejecución de ArchISO
-                     │
-                     ▼
-             Construcción de la ISO
-                     │
+              mkarchiso (sudo)
                      ▼
           out/ChurrOS-*.iso
 ```
@@ -33,179 +29,96 @@ El proceso de compilación puede resumirse de la siguiente manera:
 
 # Componentes
 
-El sistema de compilación está compuesto por tres elementos principales:
+- ArchISO (`mkarchiso`)
+- CLI de ChurrOS (`scripts/cli/build.sh`)
+- Perfil en `archiso/`
+- Workspace Rust en `rust/`
+- Paquetes locales en `archiso/packages/`
 
-- ArchISO
-- CLI de ChurrOS
-- Perfil personalizado ubicado en `archiso/`
-
----
-
-# CLI
-
-Toda la compilación se realiza mediante:
-
-```bash
-./churros build
-```
-
-Este comando automatiza completamente el proceso.
-
-No es necesario ejecutar `mkarchiso` manualmente.
+No hace falta ejecutar `mkarchiso` a mano.
 
 ---
 
 # Flujo de compilación
 
-Cuando se ejecuta:
+`./churros build` hace, en este orden:
+
+## 1. Branding y tema GRUB
+
+Copia `branding/customize_airootfs.sh` y `branding/files/` al airootfs. Regenera fuentes del tema GRUB si faltan y copia `branding/grub-theme` a `/usr/share/churros/grub-theme/`.
+
+## 2. Paquetes locales
+
+Si no están, construye Calamares y los extras AUR (`python-pywal`, `waypaper`, `yay`) en `archiso/packages/`. Si hay paquete de Calamares, `installer/apply-calamares.sh` despliega la config y se copian los `.pkg.tar.zst` a `airootfs/root/packages/`.
+
+## 3. Apps Rust
+
+`scripts/build-rust.sh` compila el workspace en release y copia los crates con `deploy = true` a `archiso/airootfs/usr/bin/`. Esos binarios no se versionan; un trap al salir del build los limpia del airootfs (junto con branding y Calamares generados).
+
+## 4. ArchISO
 
 ```bash
-./churros build
+sudo rm -rf work out
+sudo mkarchiso -v -w work -o out archiso
 ```
 
-ocurre lo siguiente:
+ArchISO instala paquetes, genera initramfs y squashfs, crea los cargadores (GRUB UEFI + Syslinux BIOS) y escribe la ISO.
 
-## 1. Limpieza
+## 5. Resultado
 
-Se elimina el directorio temporal.
+La ISO queda en `out/`. Ejemplo:
 
 ```text
-work/
+out/ChurrOS-2026.08.14-x86_64.v0.6.iso
 ```
 
-Esto evita reutilizar archivos de compilaciones anteriores.
-
----
-
-## 2. Preparación
-
-Se crea la carpeta de salida si no existe.
-
-```text
-out/
-```
-
----
-
-## 3. Construcción
-
-Se ejecuta:
-
-```bash
-mkarchiso
-```
-
-utilizando el perfil ubicado en:
-
-```text
-archiso/
-```
-
-ArchISO realiza:
-
-- instalación de paquetes
-- generación del initramfs
-- construcción del sistema Live
-- generación del sistema squashfs
-- creación del cargador UEFI
-- generación de la imagen ISO
-
----
-
-## 4. Resultado
-
-La ISO final se almacena en:
-
-```text
-out/
-```
-
-Ejemplo:
-
-```text
-out/
-
-ChurrOS-2026.07-x86_64.iso
-```
+Al terminar se borra `work/` y se devuelve `out/` al usuario.
 
 ---
 
 # Probar la distribución
 
-Para iniciar la ISO en una máquina virtual:
-
 ```bash
 ./churros run
 ```
 
-Este comando:
-
-- busca la ISO más reciente
-- inicia QEMU
-- arranca automáticamente la distribución
-
-No modifica el sistema anfitrión.
+Busca la ISO más reciente, crea el disco QEMU si hace falta e inicia la VM. Detalle en `docs/vm.md`.
 
 ---
 
 # Limpiar el proyecto
 
-Para eliminar todos los archivos temporales:
-
 ```bash
 ./churros clean
 ```
 
-Este comando elimina:
-
-```
-work/
-out/
-```
-
-No elimina ningún archivo del proyecto.
+Elimina `work/` y `out/`. No toca el código fuente.
 
 ---
 
 # Directorios utilizados
 
-## archiso/
-
-Perfil de ArchISO.
-
-Contiene todo el sistema Live.
-
----
-
-## work/
-
-Archivos temporales generados durante la compilación.
-
-Puede eliminarse sin problemas.
-
----
-
-## out/
-
-Imágenes ISO generadas.
+| Ruta | Uso |
+|------|-----|
+| `archiso/` | Perfil Live |
+| `rust/` | Código de las apps oficiales |
+| `branding/` | Identidad y script live |
+| `installer/` | Config de Calamares |
+| `work/` | Temporal de ArchISO |
+| `out/` | ISO generada |
 
 ---
 
 # Branding
 
-Durante la compilación también se aplican las personalizaciones de ChurrOS.
+Durante la compilación se integran:
 
-Entre ellas:
+- hostname, issue, motd, os-release
+- logos y fondos
+- tema GRUB
+- configuraciones del Live
 
-- hostname
-- issue
-- motd
-- os-release
-- logos
-- fondos de pantalla
-- configuraciones del sistema
-
-El branding forma parte del proceso de construcción y queda integrado dentro de la imagen Live.
+Editar la copia generada en `archiso/airootfs/root/customize_airootfs.sh` no sirve: se regenera en cada build.
 
 ---
 
@@ -213,100 +126,65 @@ El branding forma parte del proceso de construcción y queda integrado dentro de
 
 ## La ISO no aparece
 
-Comprueba que exista:
-
-```text
-out/
-```
-
-Si está vacía:
-
 ```bash
+ls out/
 ./churros build
 ```
 
----
-
 ## Error de permisos
-
-Si aparecen errores relacionados con permisos, elimina el directorio temporal:
 
 ```bash
 ./churros clean
+./churros build
 ```
 
-y vuelve a compilar.
-
----
+`mkarchiso` necesita `sudo`.
 
 ## ArchISO no encontrado
-
-Comprueba que esté instalado.
 
 ```bash
 pacman -Q archiso
 ```
 
----
+## Falla la compilación Rust
+
+```bash
+pacman -Q rust cargo
+cargo build --release --manifest-path rust/Cargo.toml
+```
 
 ## La compilación falla
 
-Revisa el registro mostrado por `mkarchiso`.
-
-La mayoría de los errores se producen por:
-
-- paquetes inexistentes
-- rutas incorrectas
-- permisos
-- configuraciones inválidas
+Revisa el registro de `mkarchiso`. Suele deberse a paquetes inexistentes, rutas incorrectas, permisos o config inválida.
 
 ---
 
 # Buenas prácticas
 
-Se recomienda seguir siempre el siguiente flujo:
-
 ```
 Modificar archivos
-
-↓
-
-Compilar
-
-↓
-
-Probar en QEMU
-
-↓
-
-Corregir errores
-
-↓
-
-Commit
-
-↓
-
-Push
+        ↓
+./churros check
+        ↓
+./churros build
+        ↓
+./churros run
+        ↓
+Corregir
+        ↓
+Commit + pull request
 ```
 
-Nunca realizar cambios directamente sobre la ISO generada.
-
-Todas las modificaciones deben hacerse sobre el código fuente del proyecto.
+Nunca modificar la ISO generada. Todos los cambios van en el código fuente.
 
 ---
 
 # Futuro
 
-El sistema de compilación evolucionará conforme avance el desarrollo de ChurrOS.
-
-Entre las mejoras planificadas se encuentran:
+Mejoras previstas:
 
 - Compilaciones incrementales.
-- Verificación automática de errores.
-- Generación de checksums.
-- Generación automática de versiones.
-- Integración con GitHub Actions.
-- Creación automática de Releases.
+- Generación de checksums desde la CLI.
+- Comando `./churros release`.
 
-El objetivo es que generar una nueva versión de ChurrOS sea un proceso completamente automatizado y reproducible.
+`./churros check` y el workflow de GitHub Actions ya cubren la verificación estática. El release v0.6 se publica a mano en GitHub Releases (ISO partida en 7z).

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -49,11 +49,12 @@ Construye una nueva imagen ISO de ChurrOS.
 
 Este comando realiza automáticamente:
 
+- Copia de branding y tema GRUB al airootfs.
+- Construcción de paquetes AUR locales si faltan (Calamares, python-pywal, waypaper, yay).
+- Compilación de las apps Rust (`scripts/build-rust.sh`) y despliegue en `usr/bin/`.
 - Limpieza del directorio temporal.
-- Preparación del entorno.
 - Ejecución de ArchISO.
-- Construcción de la imagen ISO.
-- Almacenamiento de la ISO en `out/`.
+- Construcción de la imagen ISO en `out/`.
 
 ---
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -101,7 +101,7 @@ Ejecuta primero:
 ./churros check
 ```
 
-Revisa la sintaxis de los scripts Bash y Python, los paquetes duplicados en `packages.x86_64`, que los comandos del autostart de Niri existan y que las traducciones compilen. Tarda unos segundos y no necesita construir la ISO. Es lo mismo que ejecuta el CI en cada Pull Request, así que si falla aquí, fallará allá.
+Revisa sintaxis Bash y Python, paquetes duplicados, comandos del autostart de Niri, entradas `.desktop`, orden de Calamares, extras AUR en `netinstall.yaml` y que las traducciones compilen. Tarda unos segundos y no necesita construir la ISO. Es lo mismo que ejecuta el CI en cada Pull Request, así que si falla aquí, fallará allá.
 
 Si el cambio toca el escritorio, el instalador o el build:
 
@@ -124,16 +124,16 @@ Se recomienda utilizar mensajes descriptivos.
 Ejemplos:
 
 ```text
-feat: add Fastfetch branding
+feat: añadir branding de Fastfetch
 
-fix: correct build script
+fix: corregir el script de build
 
-docs: update installation guide
+docs: actualizar la guía de instalación
 
-refactor: simplify CLI
-
-style: improve terminal banner
+refactor: simplificar la CLI
 ```
+
+Prefijo corto en inglés (`feat:`, `fix:`, `docs:`, `chore:`, `ci:`) y el resto en español.
 
 Evita mensajes como:
 
@@ -174,19 +174,25 @@ Ejemplo:
 branding/
 ```
 
-solo contiene recursos relacionados con la identidad visual.
+identidad visual y script live.
+
+```
+rust/
+```
+
+apps oficiales (gtk4-rs).
 
 ```
 scripts/
 ```
 
-solo contiene scripts.
+CLI y scripts de build.
 
 ```
 docs/
 ```
 
-solo contiene documentación.
+documentación.
 
 Mantener una estructura limpia facilita el mantenimiento del proyecto.
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -23,19 +23,25 @@ Todo cambio importante debe estar documentado y ser fácilmente reproducible.
 
 El ciclo de desarrollo recomendado es el siguiente:
 
+Crear una rama desde `origin/main`
+
+↓
+
 Modificar código
 
 ↓
 
-Compilar
+```bash
+./churros check
+```
+
+↓
 
 ```bash
 ./churros build
 ```
 
 ↓
-
-Probar
 
 ```bash
 ./churros run
@@ -47,15 +53,13 @@ Verificar funcionamiento
 
 ↓
 
-Realizar commit
+Commit (un cambio coherente)
 
 ↓
 
-Enviar cambios
+Pull request hacia `main`
 
-```bash
-git push
-```
+No se trabaja ni se empuja directo a `main`.
 
 ---
 
@@ -63,12 +67,10 @@ git push
 
 Antes de agregar nuevos archivos, verifica que pertenezcan al directorio correcto.
 
-Ejemplos:
-
-Configuraciones
+Apps oficiales (Rust)
 
 ```
-configs/
+rust/
 ```
 
 Documentación
@@ -77,19 +79,25 @@ Documentación
 docs/
 ```
 
-Recursos gráficos
+Identidad visual y script live
 
 ```
 branding/
 ```
 
-Scripts
+Calamares
+
+```
+installer/
+```
+
+Scripts y CLI
 
 ```
 scripts/
 ```
 
-Perfil del sistema
+Perfil del sistema Live
 
 ```
 archiso/
@@ -101,19 +109,19 @@ archiso/
 
 Los commits deben ser pequeños y representar una única modificación lógica.
 
-Ejemplos:
+Prefijo corto en inglés y el resto en español:
 
 ```
-feat: add Fastfetch branding
+feat: añadir branding de Fastfetch
 
-fix: correct build script
+fix: corregir el script de build
 
-docs: update branding guide
+docs: actualizar la guía de branding
 
-refactor: simplify CLI
+refactor: simplificar la CLI
 ```
 
-Evita realizar commits con múltiples cambios no relacionados.
+Evita commits con varios cambios no relacionados.
 
 ---
 
@@ -121,55 +129,39 @@ Evita realizar commits con múltiples cambios no relacionados.
 
 Toda nueva funcionalidad debe incluir su documentación correspondiente.
 
-Ejemplos:
-
-Nuevo comando
-
-↓
-
-Actualizar
-
-```
-docs/cli.md
-```
-
-Nuevo proceso de compilación
-
-↓
-
-Actualizar
-
-```
-docs/build-system.md
-```
-
-Nueva identidad visual
-
-↓
-
-Actualizar
-
-```
-docs/branding.md
-```
+| Cambio | Documento |
+|--------|-----------|
+| Nuevo comando CLI | `docs/cli.md` |
+| Proceso de compilación | `docs/build-system.md` |
+| App oficial | `docs/apps.md` (y el doc dedicado si existe) |
+| Identidad visual | `docs/branding.md` |
 
 ---
 
 # Pruebas
 
-Antes de realizar un commit se recomienda ejecutar:
+Antes de un commit de código:
+
+```bash
+./churros check
+```
+
+Si el cambio toca el escritorio, el instalador o el build:
 
 ```bash
 ./churros build
-```
-
-y posteriormente:
-
-```bash
 ./churros run
 ```
 
-La ISO debe iniciar correctamente y los cambios deben verificarse manualmente.
+La ISO debe iniciar correctamente y los cambios deben verificarse a mano. No hay suite de tests de las apps GTK todavía.
+
+Para iterar una app Rust sin reconstruir la ISO:
+
+```bash
+cargo build --release --manifest-path rust/Cargo.toml
+```
+
+El binario queda en `rust/target/release/<nombre>`.
 
 ---
 
@@ -185,17 +177,9 @@ La ISO debe iniciar correctamente y los cambios deben verificarse manualmente.
 
 # Ramas
 
-Actualmente el proyecto utiliza las siguientes ramas:
+`main` es la rama estable. Cada cambio va en su propia rama (`fix/…`, `feat/…`, `docs/…`) y entra por pull request.
 
-main
-
-Versión estable.
-
-archiso
-
-Desarrollo activo.
-
-En el futuro podrán añadirse ramas específicas para nuevas funcionalidades.
+No reutilizar ramas ya fusionadas. Partir siempre de `origin/main` actualizado.
 
 ---
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -8,11 +8,9 @@ Esta guía explica cómo preparar el sistema, obtener el código fuente del proy
 
 # Requisitos
 
-Actualmente ChurrOS está pensado para desarrollarse sobre Arch Linux o una distribución basada en Arch.
+ChurrOS está pensado para desarrollarse sobre Arch Linux o una distribución basada en Arch.
 
 ## Paquetes necesarios
-
-Instala los siguientes paquetes:
 
 ```bash
 sudo pacman -S \
@@ -20,11 +18,13 @@ sudo pacman -S \
     git \
     qemu-full \
     edk2-ovmf \
+    rust \
+    cargo \
     virt-manager \
     swtpm
 ```
 
-Algunos paquetes son opcionales dependiendo del flujo de trabajo.
+`./churros build` puede instalar `rust`/`cargo` si faltan, pero conviene tenerlos de antemano.
 
 | Paquete | Obligatorio |
 |----------|-------------|
@@ -32,8 +32,15 @@ Algunos paquetes son opcionales dependiendo del flujo de trabajo.
 | git | ✅ |
 | qemu-full | ✅ |
 | edk2-ovmf | ✅ |
+| rust / cargo | ✅ (compila las apps oficiales) |
 | virt-manager | Opcional |
 | swtpm | Opcional |
+
+Comprueba el entorno con:
+
+```bash
+./churros doctor
+```
 
 ---
 
@@ -45,6 +52,8 @@ git clone https://github.com/Hoyuse/ChurrOS.git
 cd ChurrOS
 ```
 
+No se trabaja directo en `main`. Crea una rama por cambio y abre un pull request.
+
 ---
 
 # Estructura inicial
@@ -55,39 +64,39 @@ Después de clonar el proyecto encontrarás una estructura similar a la siguient
 ChurrOS
 ├── archiso/
 ├── branding/
-├── configs/
 ├── docs/
 ├── installer/
+├── po/
+├── rust/
 ├── scripts/
-├── out/
-├── work/
 ├── churros
+├── VERSION
 └── README.md
 ```
+
+`out/`, `work/` y `vm/` aparecen al construir o ejecutar la ISO.
 
 ---
 
 # Compilar la ISO
 
-Para construir una nueva imagen de ChurrOS simplemente ejecuta:
-
 ```bash
 ./churros build
 ```
 
-Este comando realizará automáticamente las siguientes tareas:
+Este comando:
 
-1. Limpiar compilaciones anteriores.
-2. Preparar el entorno de trabajo.
-3. Ejecutar ArchISO.
-4. Generar la imagen ISO.
-5. Guardarla dentro de la carpeta `out/`.
+1. Copia branding y tema GRUB al airootfs.
+2. Construye paquetes AUR locales si faltan.
+3. Compila las apps Rust y las deja en `usr/bin/`.
+4. Ejecuta ArchISO (`mkarchiso`).
+5. Deja la ISO en `out/`.
+
+Hace falta `sudo` para `mkarchiso`.
 
 ---
 
 # Ejecutar la ISO
-
-Para probar la distribución rápidamente:
 
 ```bash
 ./churros run
@@ -97,44 +106,39 @@ Este comando:
 
 - Construye la ISO si es necesario.
 - Inicia una máquina virtual mediante QEMU.
-- Arranca directamente desde la última ISO generada.
+- Arranca desde la última ISO generada.
 
-No modifica tu sistema anfitrión.
+No modifica el sistema anfitrión. Flags útiles: `--fresh` (UEFI limpia), `--nokvm`, `--clean`. Detalle en `docs/vm.md`.
 
 ---
 
 # Limpiar archivos temporales
 
-Para eliminar todos los archivos generados durante la compilación:
-
 ```bash
 ./churros clean
 ```
 
-Este comando elimina:
-
-- work/
-- out/
+Elimina `work/` y `out/`.
 
 ---
 
 # Flujo de trabajo recomendado
 
-Durante el desarrollo se recomienda seguir siempre este flujo:
-
 Modificar archivos
 
 ↓
 
-Compilar
+```bash
+./churros check
+```
+
+↓
 
 ```bash
 ./churros build
 ```
 
 ↓
-
-Probar
 
 ```bash
 ./churros run
@@ -146,25 +150,20 @@ Verificar cambios
 
 ↓
 
-Realizar commit
-
-↓
-
-Push al repositorio
+Commit en una rama y pull request
 
 ---
 
 # Primeros cambios recomendados
 
-Si acabas de comenzar a contribuir al proyecto, puedes empezar modificando:
+Si acabas de comenzar a contribuir, puedes empezar por:
 
-- Branding
 - Documentación
-- Configuración del escritorio
-- Fastfetch
-- Wallpapers
+- CLI (`scripts/cli/`)
+- Apps en `rust/`
+- Configuración del escritorio (con cuidado: el skel temático no se toca salvo bugs)
 
-Estos componentes permiten familiarizarse con la estructura del proyecto sin afectar partes críticas del sistema.
+Estos componentes permiten familiarizarse con la estructura sin tocar branding ni el instalador.
 
 ---
 
@@ -172,40 +171,35 @@ Estos componentes permiten familiarizarse con la estructura del proyecto sin afe
 
 ## La ISO no se genera
 
-Comprueba que `archiso` esté instalado correctamente.
+Comprueba que `archiso` esté instalado.
 
 ```bash
 pacman -Q archiso
 ```
 
----
-
 ## QEMU no inicia
-
-Verifica que los paquetes necesarios estén instalados.
 
 ```bash
 qemu-system-x86_64 --version
 ```
 
----
+## Falla la compilación Rust
+
+```bash
+pacman -Q rust cargo
+cargo build --release --manifest-path rust/Cargo.toml
+```
 
 ## No aparece la ISO
 
-Comprueba el contenido de la carpeta:
-
 ```bash
-out/
+ls out/
 ```
 
-Si está vacía, ejecuta nuevamente:
-
-```bash
-./churros build
-```
+Si está vacía, ejecuta de nuevo `./churros build`.
 
 ---
 
 # Siguiente paso
 
-Una vez que puedas generar correctamente una ISO de ChurrOS, continúa con la documentación de **Project Structure**, donde se explica en detalle la función de cada directorio del proyecto.
+Cuando puedas generar una ISO, continúa con **Project Structure** (`docs/project-structure.md`) y **Apps** (`docs/apps.md`).

--- a/docs/goals.md
+++ b/docs/goals.md
@@ -1,30 +1,28 @@
-#Objetivo de ChurrOS
+# Objetivo de ChurrOS
 
-## Filosofia
+## Filosofía
 
-Churros es una distribucion basada en Arch Linux enfocada en:
+ChurrOS es una distribución basada en Arch Linux enfocada en:
 
 - Simplicidad.
 - Alto rendimiento.
-- Diseno moderno.
+- Diseño moderno.
 - Niri listo para usar.
-- Configuracion minima despues de instalar.
+- Configuración mínima después de instalar.
 
-## Publico objetivo
+## Público objetivo
 
 - Usuarios nuevos que quieran Arch sin configurarlo desde cero.
-- Desarroladores.
-- Gamers
-- Personas que quieran un escritorio bonito desde el primer inicio.
+- Desarrolladores.
+- Personas que quieran un escritorio cuidado desde el primer inicio.
 
-## Caracteristicas
+## Características
 
-- Instalador grafico.
+- Instalador gráfico (Calamares).
 - Niri por defecto.
-- Quickshell.
+- Waybar, foot, Fuzzel y Mako.
 - Tema propio.
 - Wallpapers propios.
-- greetd con autologin.
-- Drivers automaticos.
-- Soporte para NVIDIA y AMD
-
+- greetd con autologin en la sesión Live.
+- Apps oficiales en Rust (welcome, settings, control-center, popups).
+- Soporte para NVIDIA y AMD.

--- a/docs/project-structure.md
+++ b/docs/project-structure.md
@@ -15,14 +15,18 @@ ChurrOS
 ├── docs/
 ├── installer/
 ├── po/
+├── rust/
 ├── scripts/
 ├── out/
 ├── vm/
 ├── work/
 ├── churros
+├── VERSION
 ├── LICENSE
 └── README.md
 ```
+
+`out/`, `vm/` y `work/` no forman parte del código fuente: se generan al construir o probar.
 
 ---
 
@@ -30,128 +34,110 @@ ChurrOS
 
 ## archiso/
 
-Contiene el perfil de ArchISO utilizado para construir la distribución.
+Perfil de ArchISO usado para construir la ISO Live.
 
-Aquí se encuentra todo lo relacionado con la imagen Live de ChurrOS.
+Incluye:
 
-Ejemplos:
-
-- paquetes
-- configuración del sistema
-- archivos del Live ISO
-- servicios
-- hooks
+- `packages.x86_64` — lista de paquetes
+- `profiledef.sh` — metadatos, bootmodes (`bios.syslinux` + `uefi.grub`) y permisos
+- `airootfs/` — overlay del sistema Live (skel, servicios, assets)
+- `grub/` y `syslinux/` — cargadores de la ISO
+- `packages/` — repo pacman local (Calamares y extras AUR construidos en el host)
 
 Es el corazón de la distribución.
 
 ---
 
+## rust/
+
+Workspace Cargo de las apps oficiales (gtk4-rs + libadwaita):
+
+| Crate | Binario | `deploy` |
+|-------|---------|----------|
+| `churros-welcome` | `churros-welcome` | sí |
+| `preferences` | `churros-settings` | sí |
+| `control-center` | `churros-control-center` | sí |
+| `popups` | `churros-popup` | sí |
+| `services` | librería `churros_services` | no (la usan las demás) |
+
+`scripts/build-rust.sh` (lo invoca `./churros build`) compila en release y copia los binarios con `deploy = true` a `archiso/airootfs/usr/bin/`. Esos binarios no se versionan. Los assets de runtime viven en `archiso/airootfs/usr/share/churros/<app>/`.
+
+---
+
 ## branding/
 
-Contiene todos los recursos relacionados con la identidad de ChurrOS.
-
-Ejemplos:
+Identidad de la distribución y script que se aplica al arrancar el Live.
 
 ```text
 branding
-├── files/
-├── logos/
-├── wallpapers/
-└── fastfetch/
+├── customize_airootfs.sh
+├── files/          # os-release, issue, motd
+├── grub-theme/     # tema del GRUB instalado
+├── colors.md
+├── typography.md
+├── logo-guidelines.md
+├── mascot.md
+└── ui-guidelines.md
 ```
 
-Aquí se almacenan elementos como:
+`customize_airootfs.sh` se copia al airootfs en cada build; editar la copia en `archiso/airootfs/root/` no tiene efecto.
 
-- issue
-- motd
-- os-release
-- hostname
-- logos
-- fondos de pantalla
-- fastfetch
-- futuras imágenes del instalador
-
-Todo lo relacionado con la identidad visual debe vivir aquí.
+Los wallpapers y el resto de assets de escritorio viven en `archiso/airootfs/usr/share/churros/`, no en carpetas `branding/wallpapers/` o `branding/logos/`.
 
 ---
 
 ## docs/
 
-Documentación oficial del proyecto.
-
-Incluye:
-
-- instalación
-- desarrollo
-- branding
-- estructura
-- roadmap
-- contribución
-
-Toda funcionalidad importante debe estar documentada.
+Documentación oficial del proyecto. Toda funcionalidad importante debe estar documentada.
 
 ---
 
 ## installer/
 
-Reservado para el futuro instalador gráfico de ChurrOS.
-
-Actualmente la distribución utiliza ArchISO, pero este directorio contendrá el código fuente del instalador propio.
-
-Ejemplo futuro:
+Configuración de Calamares (no un instalador propio todavía):
 
 ```text
 installer
-├── backend/
-├── frontend/
-├── assets/
-└── translations/
+├── apply-calamares.sh
+└── calamares/
+    ├── settings.conf
+    └── modules/
 ```
+
+`apply-calamares.sh` despliega la config y la regla polkit al airootfs durante el build.
+
+---
+
+## po/
+
+Traducciones gettext (`*.po`). `./churros check` las valida con `msgfmt --check`.
 
 ---
 
 ## scripts/
 
-Scripts auxiliares utilizados durante el desarrollo.
+Scripts de desarrollo. No forman parte del sistema instalado.
 
-Ejemplos:
-
-- automatización
-- compilación
-- pruebas
-- generación de archivos
-
-Los scripts no forman parte del sistema instalado.
+- `scripts/cli/` — subcomandos de `./churros` (`build`, `run`, `check`, `doctor`, …)
+- `scripts/build-rust.sh`, `build-calamares.sh`, `build-aur.sh`, `build-grub-theme.sh`
 
 ---
 
 ## out/
 
-Directorio donde se generan las imágenes ISO.
-
-Ejemplo:
-
-```text
-out/
-
-ChurrOS-2026.07-x86_64.iso
-```
-
-No debe modificarse manualmente.
-
-Su contenido puede eliminarse sin afectar el proyecto.
+ISO generada (`ChurrOS-*.iso`). Se puede borrar sin afectar el proyecto.
 
 ---
 
 ## work/
 
-Directorio temporal utilizado por ArchISO.
+Directorio temporal de ArchISO. No forma parte del repositorio.
 
-Contiene archivos generados durante la compilación.
+---
 
-No forma parte del repositorio.
+## vm/
 
-Puede eliminarse en cualquier momento.
+Disco QEMU (`ChurrOS.qcow2`) y variables UEFI (`OVMF_VARS.fd`). Gitignorados; cada desarrollador los genera con `./churros run`.
 
 ---
 
@@ -159,75 +145,52 @@ Puede eliminarse en cualquier momento.
 
 ## churros
 
-CLI oficial de desarrollo.
-
-Permite ejecutar comandos como:
+CLI oficial de desarrollo. Despacha a `scripts/cli/<comando>.sh`.
 
 ```bash
 ./churros build
 ./churros run
+./churros check
 ./churros clean
 ```
 
-En el futuro incorporará nuevas funciones para facilitar el desarrollo.
+## VERSION
 
----
+Número de versión del proyecto. Lo leen `./churros version` y `./churros info`.
 
 ## README.md
 
 Página principal del proyecto.
 
-Es la primera documentación que verá cualquier usuario o colaborador.
-
----
-
 ## LICENSE
 
-Licencia oficial del proyecto: GNU General Public License v3.0 (GPL-3.0).
+GNU General Public License v3.0 (GPL-3.0).
 
 ---
 
 # Flujo del proyecto
 
-El flujo general de desarrollo es el siguiente:
-
 ```text
 Modificar código
-
-↓
-
-Compilar
-
-↓
-
-Generar ISO
-
-↓
-
-Probar en máquina virtual
-
-↓
-
-Realizar cambios
-
-↓
-
-Commit
-
-↓
-
-Push
+        ↓
+./churros check
+        ↓
+./churros build
+        ↓
+./churros run
+        ↓
+Commit en una rama
+        ↓
+Pull request hacia main
 ```
+
+No se trabaja directo en `main`.
 
 ---
 
 # Organización del repositorio
 
 Cada carpeta tiene una única responsabilidad.
-
-No deben mezclarse archivos de distinta naturaleza.
-
-Ejemplo:
 
 ❌ Incorrecto
 
@@ -241,28 +204,27 @@ branding/
 
 ```
 branding/
-    wallpaper.png
+    files/os-release
 
 scripts/
-    build.sh
+    build-rust.sh
+
+archiso/airootfs/usr/share/churros/wallpapers/
+    fondo.png
 ```
 
 ---
 
 # Convenciones
 
-Durante el desarrollo se siguen las siguientes reglas:
-
 - Mantener una estructura simple.
 - Utilizar nombres descriptivos.
 - Evitar duplicar archivos.
-- Mantener separados el código, la documentación y los recursos gráficos.
+- Separar código, documentación y recursos gráficos.
 - Documentar cualquier cambio importante.
 
 ---
 
 # Objetivo
 
-La estructura del proyecto debe permanecer organizada incluso cuando ChurrOS crezca considerablemente.
-
-Una buena organización facilita el mantenimiento, reduce errores y mejora la colaboración entre desarrolladores.
+La estructura del proyecto debe permanecer organizada incluso cuando ChurrOS crezca. Una buena organización facilita el mantenimiento, reduce errores y mejora la colaboración.

--- a/docs/vm.md
+++ b/docs/vm.md
@@ -62,7 +62,7 @@ El script `scripts/cli/run.sh` lanza QEMU con los siguientes parámetros:
 
 ## UEFI
 
-Se usa OVMF (Open Virtual Machine Firmware) para que la VM arranque en modo UEFI, igual que la mayoría de PCs modernos. Esto es importante porque la ISO de ChurrOS incluye entradas systemd-boot que solo funcionan en UEFI.
+Se usa OVMF (Open Virtual Machine Firmware) para que la VM arranque en modo UEFI, igual que la mayoría de PCs modernos. En UEFI la ISO usa GRUB (`uefi.grub`); en BIOS legacy usa Syslinux.
 
 Los dos archivos de firmware:
 


### PR DESCRIPTION
Ajusta estructura, getting-started, build, contributing y arquitectura al repo real: rust/, Calamares, GRUB+Syslinux, sin configs/ ni systemd-boot como cargador actual.