### PR TITLE
docs: actualizar apps, popups y servicios al stack Rust

### DIFF
--- a/archiso/airootfs/usr/share/churros/churros-welcome/README.md
+++ b/archiso/airootfs/usr/share/churros/churros-welcome/README.md
@@ -9,11 +9,12 @@ despliega en `/usr/bin/churros-welcome` durante el build (`scripts/build-rust.sh
 Los assets (SVG + style.css) siguen aquí para el runtime de la ISO; el crate
 tiene su propia copia en `rust/churros-welcome/assets/` para desarrollo.
 
-Muestra información del sistema (CPU, RAM, kernel, SO, arquitectura, hostname) y
-accesos directos a:
+Muestra accesos directos a:
 
 - Instalar ChurrOS (Calamares)
 - Repositorio en GitHub
 - Comunidad
+
+La tarjeta de información del sistema (`system_card.rs`) está en el crate pero no se monta en la ventana.
 
 Más detalles en `docs/apps.md`.

--- a/docs/apps.md
+++ b/docs/apps.md
@@ -2,252 +2,194 @@
 
 Este documento describe las aplicaciones oficiales de ChurrOS.
 
-Todas las apps están escritas en **Python 3** usando **GTK4** y **Libadwaita**. La estructura común es:
+Desde **v0.5 / v0.6** todas las apps oficiales están escritas en **Rust** con **gtk4-rs** y **libadwaita**. El código Python de `/usr/share/churros/` se eliminó del repositorio; en runtime solo quedan assets (CSS, SVG) y los binarios que despliega `scripts/build-rust.sh`.
 
 ```text
-app/
-├── main.py             # Entry point (Gtk.Application)
-├── window.py           # Ventana principal
-├── widgets/            # Componentes reutilizables
-├── services/           # (opcional) Lógica de negocio
-├── assets/             # Iconos, CSS
-└── README.md
+rust/
+├── Cargo.toml              # workspace
+├── churros-welcome/        # binario churros-welcome
+├── preferences/            # binario churros-settings
+├── control-center/         # binario churros-control-center
+├── popups/                 # binario churros-popup
+└── services/               # crate churros_services (no se despliega)
 ```
 
-Las apps se instalan en `/usr/share/churros/<app>/` dentro de la ISO Live y se ejecutan mediante binarios en `/usr/bin/` (wrappers que hacen `cd` al directorio de la app y llaman a `python3 main.py`).
+Cada crate con `deploy = true` en `Cargo.toml` se copia a `archiso/airootfs/usr/bin/<nombre>` al construir la ISO. Los binarios no se versionan.
+
+En desarrollo, los crates resuelven assets a `rust/<crate>/assets/` si no existe `/usr/share/churros/<app>/`.
 
 ---
 
 # churros-welcome
 
-**Path (Rust):** `rust/churros-welcome/`
-**Instalada en:** `/usr/bin/churros-welcome` (binario ELF compilado)
+**Path:** `rust/churros-welcome/`
+**Binario:** `/usr/bin/churros-welcome`
 **Autostart:** `archiso/airootfs/etc/skel/.config/niri/config.kdl` (`spawn-at-startup "churros-welcome"`)
+**Assets:** `archiso/airootfs/usr/share/churros/churros-welcome/assets/`
 
-La pantalla de bienvenida que se muestra al iniciar la sesión Live. **Portada a Rust (gtk4-rs + libadwaita-rs)** — el código Python original fue reemplazado; los assets (SVG/CSS) siguen en `archiso/airootfs/usr/share/churros/churros-welcome/assets/` y se leen desde `/usr/share/churros/churros-welcome/assets/` en runtime.
-
-El binario se compila con `scripts/build-rust.sh` (invocado por `./churros build`) y se despliega en `archiso/airootfs/usr/bin/`. No se versiona en git: en un checkout limpio solo existe el crate en `rust/churros-welcome/`.
+Pantalla de bienvenida al iniciar la sesión Live.
 
 ## Purpose
 
 - Dar la bienvenida al usuario.
-- Mostrar información básica del sistema (CPU, RAM, kernel, SO, arquitectura, hostname).
-- Ofrecer accesos rápidos a documentación, GitHub, comunidad, personalización y actualización.
+- Ofrecer accesos a instalación, GitHub y comunidad.
+
+`system_card.rs` y `system_info.rs` existen (leen `/proc` y `/etc/os-release`) pero la `SystemCard` **no se monta** en la ventana actual. El footer muestra `Linux • Niri • ChurrOS` (versión embebida en el crate; hoy no lee `VERSION` del repo).
 
 ## Stack
 
-- **GTK 4.0** + **Libadwaita 1** (a través de PyGObject)
-- **psutil** (opcional): con fallback a `/proc/meminfo` si no está disponible
-- **Python 3.14+**
+- GTK 4 + Libadwaita (gtk4-rs / libadwaita-rs)
+- Sin psutil: CPU, RAM, kernel y hostname salen de `/proc`
 
 ## Window
 
-- Tamaño por defecto: 1100×720 (definido en `src/config/constants.py`)
-- Tamaño mínimo: 640×480 (para pantallas pequeñas)
-- Layout: vertical con scroll (`Gtk.ScrolledWindow`)
-- CSS cargado desde `assets/style.css` con prioridad `APPLICATION`
+- Maximizada, sin decoración
+- Tamaño mínimo: 640×480
+- Layout vertical con scroll
+- CSS: `/usr/share/churros/styles/churros.css` + `assets/style.css`
 
-## Structure (Rust)
+## Structure
 
 ```text
 rust/churros-welcome/
-├── Cargo.toml              # gtk4 (v4_22) + libadwaita + glib + gio
-├── assets/                 # Copia local para desarrollo (SVG + style.css)
+├── Cargo.toml
+├── assets/
 └── src/
-    ├── main.rs             # Adw::Application + carga de CSS + ventana maximizada
-    ├── header.rs           # Logo, título, subtítulo, separador
-    ├── cards.rs            # FlowBox con las 3 ActionCards
-    ├── footer.rs           # "Linux • Niri • ChurrOS {VERSION}"
-    ├── action_card.rs      # Gtk::Button 280x340 con icono/título/descripción
-    ├── system_card.rs      # Definida pero NO montada (igual que en Python original)
-    ├── system_info.rs      # get_cpu, get_memory, get_kernel, get_os, etc. (lectura /proc)
-    ├── actions.rs          # Abrir URLs (gio::AppInfo) + lanzar calamares.desktop
-    └── assets.rs           # Resolución de rutas: /usr/share/churros/... o assets/ local
+    ├── main.rs
+    ├── header.rs
+    ├── cards.rs            # FlowBox con 3 ActionCards
+    ├── footer.rs
+    ├── action_card.rs
+    ├── system_card.rs      # Definida, no montada
+    ├── system_info.rs
+    ├── actions.rs          # URLs + calamares.desktop
+    └── assets.rs
 ```
-
-Las funciones de `system_info` leen directamente de `/proc` (cpuinfo, meminfo, os-release, osrelease, hostname), igual que el Python con fallback a psutil — el resultado es el mismo.
-
-## System Card
-
-La `SystemCard` muestra información en tiempo real del sistema:
-
-| Campo | Fuente | Fallback |
-|-------|--------|----------|
-| CPU | `/proc/cpuinfo` (`model name`) | "Desconocido" |
-| RAM | `psutil.virtual_memory()` o `/proc/meminfo` | "Desconocido" |
-| Kernel | `platform.release()` | — |
-| SO | `/etc/os-release` (`PRETTY_NAME`) | `platform.system()` |
-| Arquitectura | `platform.machine()` | — |
-| Hostname | `platform.node()` | — |
-
-La memoria RAM usa `psutil` si está disponible. Si no, lee `/proc/meminfo` directamente y formatea en GiB. Esto permite que la app funcione incluso si `psutil` no se instaló en la ISO.
 
 ## Action Cards
 
-La pantalla principal muestra la `SystemCard` más 3 tarjetas de acción:
+| Icono | Título | Acción |
+|-------|--------|--------|
+| install.svg | Install ChurrOS | Lanza `calamares.desktop` |
+| github.svg | GitHub | Abre el repositorio |
+| community.svg | Comunidad | Abre el servidor de comunidad |
 
-| Icono | Título | Callback |
-|-------|--------|----------|
-| install.svg | Install ChurrOS | Lanza `calamares.desktop` vía `Gio.DesktopAppInfo.new("calamares.desktop").launch()`. Si no existe muestra un `Gtk.AlertDialog` informativo. |
-| github.svg | GitHub | Abre el repositorio en el navegador. |
-| community.svg | Comunidad | Abre el servidor de comunidad. |
-
-La `SystemCard` no es clickable, solo informativa (CPU, RAM, kernel, SO, arquitectura, hostname). Se muestra la primera en el FlowBox.
-
-Las tarjetas están organizadas en un `Gtk.FlowBox` con un máximo de 3 columnas y mínimo de 1. En pantallas estrechas se reorganizan automáticamente.
+Máximo 3 columnas; en pantallas estrechas se apilan.
 
 ## Desktop Entry
 
-`archiso/airootfs/usr/share/applications/churros-welcome.desktop`:
-
-```ini
-[Desktop Entry]
-Name=ChurrOS Welcome
-Exec=churros-welcome
-Terminal=false
-Categories=System;
-X-GNOME-Autostart-enabled=true
-```
+`archiso/airootfs/usr/share/applications/churros-welcome.desktop` — `Exec=churros-welcome`.
 
 ---
 
 # churros-control-center
 
-**Path:** `archiso/airootfs/usr/share/churros/control-center/`
-**Wrapper:** `/usr/bin/churros-control-center` (o `python /usr/share/churros/control-center/main.py` desde desktop entry)
+**Path:** `rust/control-center/`
+**Binario:** `/usr/bin/churros-control-center`
 **Desktop entry:** `archiso/airootfs/usr/share/applications/churros-control-center.desktop`
+**Atajo:** `Mod + C` (niri)
 
-Centro de control con tarjetas para los componentes principales del sistema.
+Centro de control con tarjetas que abren el popup correspondiente (`churros-popup <nombre>`).
 
 ## Window
 
-- Tamaño: 520×570, no redimensionable, sin decoración de ventana
-- Layout: `Gtk.Grid` con 2 columnas y 3 filas
-- Espaciado: 12px entre celdas, 16px de margen
-- CSS: estilo dark con acento naranja (`#ff8c00`)
+- 430×650, no redimensionable, sin decoración
+- Header: logo, título, botón de settings (`churros-settings`) y botón de power
+- Grid 2×2 (red, bluetooth, brillo, batería) + tarjeta de audio a ancho completo
+- Refresh asíncrono cada 2 s (`churros_services` en un hilo)
 
 ## Cards
 
-| Fila | Columna 0 | Columna 1 |
-|------|-----------|-----------|
-| 0 | NetworkCard | BluetoothCard |
-| 1 | BrightnessCard | BatteryCard |
-| 2 | AudioCard (ancho completo) | — |
-
-Cada card es un `Card` (Gtk.Button) que al hacer clic llama a `popup_launcher.open_<name>(window)`, que lanza el popup correspondiente en un proceso separado (vía `subprocess.Popen([sys.executable, popup_main])`).
-
-Header del control center tiene un botón de "Settings" (icon `preferences-system`) que lanza `churros-settings` y cierra el control center.
+| Posición | Tarjeta | Popup |
+|----------|---------|-------|
+| 0,0 | Network | `churros-popup network` |
+| 0,1 | Bluetooth | `churros-popup bluetooth` |
+| 1,0 | Brightness | `churros-popup brightness` |
+| 1,1 | Battery | `churros-popup battery` |
+| debajo | Audio | (controles in-place + popup de audio) |
 
 ## Services
 
-Cada tarjeta consulta un servicio compartido en `/usr/share/churros/services/`:
+Usa el crate `churros_services` (`rust/services/`): wifi, ethernet, bluetooth, brightness, battery, audio. Detalle en `docs/services.md`.
 
-- `services/wifi.py` + `services/ethernet.py` → `widgets/network.py` → NetworkCard
-- `services/bluetooth.py` → `widgets/bluetooth.py` → BluetoothCard
-- `services/audio.py` → `widgets/audio.py` → AudioCard
-- `services/brightness.py` → `widgets/brightness.py` → BrightnessCard
-- `services/battery.py` → `widgets/battery.py` → BatteryCard
-
-i18n: el control center importa `from i18n import _` desde `/usr/share/churros/i18n.py` (módulo central añadido para que popups + control center + preferences lo compartan).
-
-## Style
-
-- Fondo: variables CSS del `style.css` del propio control center.
-- Acento: `#DE8636` (ChurrOS naranja).
-- Polling: cada 2s hace refresh de todas las cards (vía `GLib.timeout_add_seconds(2, self.refresh)`).
+Logs de arranque: `/tmp/churros/churros-control-center.log`.
 
 ---
 
 # churros-settings
 
-**Path:** `archiso/airootfs/usr/share/churros/preferences/`
-**Wrapper:** `/usr/bin/churros-settings` → `python3 /usr/share/churros/preferences/main.py`
-**Keybind:** `SUPER + P` (definido en `archiso/airootfs/etc/skel/.config/niri/config.kdl`)
+**Path:** `rust/preferences/`
+**Binario:** `/usr/bin/churros-settings`
+**Atajo:** `Mod + P` (niri)
 
-App de configuración principal, estilo System Settings de macOS con colores ChurrOS. Documentación dedicada en `docs/preferences.md`.
+App de configuración principal, estilo System Settings con colores ChurrOS. Documentación dedicada en `docs/preferences.md`.
+
+Logs: `/tmp/churros/churros-settings.log`.
+
+---
+
+# churros-popup
+
+**Path:** `rust/popups/`
+**Binario:** `/usr/bin/churros-popup`
+
+Un solo binario con los seis popups y toggle nativo (pidfiles en `/tmp/churros/`). Documentación en `docs/popups.md`.
 
 ---
 
 # fuzzel (launcher)
 
-**Path:** binario del sistema (instalado vía `archiso/packages.x86_64`).
-**Keybind:** `SUPER + SPACE` (definido en `archiso/airootfs/etc/skel/.config/niri/config.kdl`)
-**Waybar:** `custom/launcher` → `on-click: "fuzzel"` (clic derecho → foot).
+**Path:** paquete del sistema (`archiso/packages.x86_64`).
+**Atajo:** `Mod + Space`
+**Waybar:** `custom/launcher` → `fuzzel`
 
-El launcher de aplicaciones es **fuzzel** ( Wayland-native, ligero), no una app ChurrOS propia. Muestra la lista de apps instaladas (leídas desde los `.desktop` del sistema), filtrado incremental por teclado, y lanza la seleccionada vía la DBus launcheable del .desktop.
-
-Config: `archiso/airootfs/etc/skel/.config/fuzzel/fuzzel.ini` (tipografía, colores, atajos).
-
-Razón: fuzzel cumple el rol de "Spotlight" sin necesitar write + mantain una app GTK4 custom para ello. Si en el futuro se quiere hacer un launcher con previews / acciones extra (estilo Raycast), sería momento de sustituirlo por una app propia.
+No es una app ChurrOS. Config: `archiso/airootfs/etc/skel/.config/fuzzel/fuzzel.ini`.
 
 ---
 
 # churros-ui (planificado)
 
-**Estado:** Aún no implementado. Idea original pendiente.
+**Estado:** no implementado.
 
-Biblioteca de componentes UI compartidos que las apps oficiales usarían para mantener una identidad visual consistente. Hoy cada app (welcome, control-center, preferences, popups) tiene su propio `style.css` con variables CSS similares pero duplicadas.
-
-Roadmap potencial:
-
-### v0.1
-- `ActionCard`
-- `InfoCard`
-- `Header`
-- `Footer`
-
-### v0.2
-- `Sidebar`
-- `Dialogs`
-- `Buttons`
-- `Navigation`
-
-### v0.3
-- Animaciones
-- Temas
-- Componentes avanzados
-
-## Consumers esperados
-
-- `churros-welcome`
-- `churros-settings`
-- `churros-control-center`
-- Popups
-- Cualquier herramienta oficial nueva
+Hoy cada app tiene su propio CSS. A largo plazo convendría un crate o stylesheet compartido más allá de `/usr/share/churros/styles/churros.css`.
 
 ---
 
 # Packaging
 
-Las apps GTK viven dentro del directorio `archiso/airootfs/usr/share/churros/<app>/`, que es lo que archiso empaqueta directamente en la ISO. Los wrappers en `/usr/bin/churros-*` ejecutan `python3` apuntando a esos paths.
-
-> **Nota:** El `build.sh` no copia automáticamente las apps Python. El código fuente *es* el árbol que termina en la ISO.
-
-**Apps Rust** (desde v0.5): el código vive en `rust/<app>/` como crate Cargo. `scripts/build-rust.sh` (invocado por `./churros build`) compila en release y despliega el binario en `archiso/airootfs/usr/bin/<app>`. El binario no se versiona (`.gitignore`). Los assets de runtime siguen en `archiso/airootfs/usr/share/churros/<app>/assets/`, y en desarrollo el crate usa su propia copia local en `rust/<app>/assets/`.
+| Qué | Dónde |
+|-----|--------|
+| Código | `rust/<crate>/` |
+| Binario en la ISO | `archiso/airootfs/usr/bin/<app>` (generado, no versionado) |
+| Assets | `archiso/airootfs/usr/share/churros/<app>/` |
+| Desktop entries | `archiso/airootfs/usr/share/applications/` |
 
 ---
 
 # Development
 
-Para modificar una app:
+1. Edita el crate en `rust/<app>/`.
+2. Compila en el host:
 
-1. **Python**: edita el código en `archiso/airootfs/usr/share/churros/<app>/`.
-2. **Rust**: edita el crate en `rust/<app>/` y compila localmente con `cargo build --release --manifest-path rust/Cargo.toml` (el binario queda en `rust/target/release/<app>`).
-3. Compila y prueba la ISO:
+```bash
+cargo build --release --manifest-path rust/Cargo.toml
+```
+
+3. Para verlo en el Live:
 
 ```bash
 ./churros build
 ./churros run
 ```
 
-3. Confirma que la app arranca y se ve correctamente.
+`./churros check` no compila Rust; valida scripts, paquetes, desktop entries y que los `spawn` de Niri resuelvan a un binario, crate con `deploy = true` o paquete de la ISO.
 
 ---
 
 # Future Work
 
-- Mover las apps a un repositorio separado: hoy viven dentro del repo de la distro. A largo plazo deberían empaquetarse e instalarse vía pacman.
-- Sustituir placeholders de las tarjetas de_action antiguas — hecho: hoy Welcome tiene Install/GitHub/Discord/Documentation/Terminal/Browser todas funcionales.
-- Internacionalización: hoy `i18n._()` (`/usr/share/churros/preferences/i18n.py` y la copia en `/usr/share/churros/i18n.py`) simplemente devuelve la string original; falta compilar `po/churros.po` a `/usr/share/locale/es/LC_MESSAGES/churros.mo`.
-- churros-ui: centralizar el CSS + widgets compartidos (hoy hay code duplication entre welcome/control-center/preferences/popups).
-- Tests: no hay suite de tests. Las apps interactúan con el sistema; verificación es `python3 -c "import ast; ast.parse(open(f).read())"` + lanzar manualmente cada app en niri.
+- Empaquetar las apps como paquetes pacman propios.
+- Leer `VERSION` del repo en el footer de welcome (hoy está embebida en el crate).
+- Completar i18n (los `.po` existen; las apps Rust aún no cargan gettext).
+- churros-ui: widgets y CSS compartidos.
+- Tests automatizados de las apps GTK.

--- a/docs/popups.md
+++ b/docs/popups.md
@@ -1,52 +1,37 @@
 # Popups
 
-Este documento describe el sistema de popups de ChurrOS: pequeñas ventanas que se muestran al interactuar con los iconos de Waybar o con atajos de teclado.
+Este documento describe el sistema de popups de ChurrOS: ventanas pequeñas al interactuar con Waybar o con atajos de teclado.
 
-Los popups son componentes individuales del escritorio: audio, batería, bluetooth, brillo, red y energía. Cada uno es un proceso GTK4 independiente que se abre, muestra su contenido y se cierra solo.
+Los seis popups viven en **un solo binario Rust** (`churros-popup`) con toggle nativo. Reemplazan al wrapper bash y a los procesos Python por popup.
 
 ---
 
 # Overview
 
-Los popups viven en:
-
 ```text
-archiso/airootfs/usr/share/churros/popups/
+rust/popups/
+├── Cargo.toml              # name = "churros-popup", deploy = true
+├── assets/                 # CSS e iconos (copia de desarrollo)
+└── src/
+    ├── main.rs             # CLI + toggle/reemplazo
+    ├── popup.rs            # PopupWindow + header + carga de CSS
+    ├── audio.rs
+    ├── battery.rs
+    ├── bluetooth.rs
+    ├── brightness.rs
+    ├── network.rs
+    └── power.rs
 ```
 
-Estructura:
+Assets de runtime: `/usr/share/churros/popups/assets/` (y CSS compartido en `/usr/share/churros/styles/churros.css`).
 
-```text
-popups/
-├── common/               # Código compartido
-│   ├── popup.py          # PopupWindow (clase base)
-│   ├── main.py           # App de prueba
-│   ├── style.css
-│   └── widgets/
-│       ├── button.py
-│       ├── card.py
-│       ├── header.py
-│       ├── icon_button.py
-│       └── separator.py
-├── audio/                # Popup de audio (volumen, mute, dispositivo)
-├── battery/              # Popup de batería
-├── bluetooth/            # Popup de Bluetooth
-├── brightness/           # Popup de brillo
-├── network/              # Popup de red (Wi-Fi + Ethernet)
-└── power/                # Popup de energía
+Uso:
+
+```bash
+churros-popup {network|audio|bluetooth|power|brightness|battery}
 ```
 
-Cada popup individual tiene esta forma:
-
-```text
-<popup>/
-├── main.py               # Entry point (Gtk.Application)
-├── window.py             # <Popup>Window (extiende PopupWindow)
-├── style.css             # Estilos específicos
-└── widgets/              # Widgets del popup
-```
-
-El launcher está en `/usr/bin/churros-popup` (script bash) y su lógica de toggle/reemplazo vive en él, no en un módulo Python separado.
+Otro nombre → exit 64.
 
 ---
 
@@ -54,91 +39,53 @@ El launcher está en `/usr/bin/churros-popup` (script bash) y su lógica de togg
 
 ## Architecture
 
-Cada popup es un proceso Python GTK4 independiente. El launcher `/usr/bin/churros-popup` (script bash) es el punto de entrada único desde Waybar o desde el teclado.
+1. Waybar o niri ejecuta `churros-popup <nombre>`.
+2. El binario lee `/tmp/churros/popup.pid` y `/tmp/churros/popup.name`.
+3. Si no hay popup → abre el solicitado (misma ventana GTK, `org.churros.popup.<nombre>`).
+4. Si el activo es el mismo → lo mata (toggle off) y sale.
+5. Si hay otro → lo mata y abre el nuevo.
 
-Flujo:
-
-1. Waybar o niri ejecuta `churros-popup <nombre>` cuando se hace clic en un módulo o se pulsa un atajo.
-2. El script revisa `/tmp/churros/popup.pid` y `/tmp/churros/popup.name` para saber qué popup está activo.
-3. Si no hay popup → lanza el solicitado (`python3 /usr/share/churros/popups/<name>/main.py`).
-4. Si el popup activo es el mismo → lo mata (toggle off).
-5. Si hay otro popup abierto → lo mata y abre el nuevo.
+El toggle ya no es un script bash: está en `rust/popups/src/main.rs`.
 
 ## Estado en disco
 
 ```text
-/tmp/churros/popup.pid     # PID del proceso del popup actual
+/tmp/churros/popup.pid     # PID del popup actual
 /tmp/churros/popup.name    # Nombre del popup activo
 ```
 
-El script valida con `kill -0 $pid` que el proceso siga vivo; si murió pero los archivos quedaron, los limpia automáticamente antes de lanzar uno nuevo.
-
-## churros-popup
-
-`/usr/bin/churros-popup` (bash, ~116 líneas):
-
-- Acepta 6 nombres: `network`, `audio`, `bluetooth`, `power`, `brightness`, `battery`.
-- Otro nombre → exit 64 (usage).
-- Comprueba que `/usr/share/churros/popups/<name>/main.py` exista.
-- `set -eu` para fallar rápido.
-- Lanza el popup con stdout/stderr a `/dev/null` (los popups no deben imprimir).
-- Espera 100ms tras lanzar para detectar fallos inmediatos (display ausente, etc.) y limpiar el PIDFILE en ese caso.
+Si el PID murió, limpia los archivos antes de lanzar uno nuevo. Al cerrar la ventana también los borra. Escape cierra el popup.
 
 ---
 
 # Available Popups
 
-| Nombre | Descripción | Servicio |
-|--------|-------------|----------|
-| `audio` | Volumen, mute, dispositivo de salida | `services/audio.py` |
-| `battery` | Porcentaje, estado, tiempo restante | `services/battery.py` |
-| `bluetooth` | Toggle y lista de dispositivos | (hardcodeado) |
-| `brightness` | Slider de brillo | `services/brightness.py` |
-| `network` | Wi-Fi (toggle + redes) + Ethernet | `services/wifi.py` + `services/ethernet.py` |
-| `power` | Lock, logout, suspend, hibernate, restart, shutdown | `services/power.py` |
+| Nombre | Descripción | Crate de servicios |
+|--------|-------------|--------------------|
+| `audio` | Volumen, mute, dispositivo de salida | `churros_services::audio` |
+| `battery` | Porcentaje, estado, tiempo restante | `churros_services::battery` |
+| `bluetooth` | Toggle y lista real vía `bluetoothctl` | `churros_services::bluetooth` |
+| `brightness` | Slider de brillo | `churros_services::brightness` |
+| `network` | Wi-Fi + Ethernet | `churros_services::wifi` + `ethernet` |
+| `power` | Lock, logout, suspend, hibernate, restart, shutdown | `churros_services::power` |
 
 ---
 
-# Base Class: PopupWindow
+# Base: PopupWindow
 
-`popups/common/popup.py` define la clase base que todos los popups extienden:
+`popup.rs` define la ventana común:
 
-```python
-class PopupWindow(Gtk.ApplicationWindow):
-
-    def __init__(self, app, title="Popup", icon="🧪"):
-
-        super().__init__(application=app)
-
-        self.set_title(title)
-        self.set_default_size(320, 400)
-        self.set_resizable(False)
-        self.set_decorated(False)
-        self.add_css_class("popup")
-
-        # Header con icono + título
-        self.header = Header(icon, title)
-        self.main_box.append(self.header)
-
-        # Contenido (lo añade cada popup con self.add(widget))
-        self.content = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
-        self.content.set_vexpand(True)
-        self.main_box.append(self.content)
-```
-
-Características comunes a todos los popups:
-
-- Tamaño fijo 320×400 (puede ser mayor si el contenido lo requiere)
-- Sin decoración de ventana
-- CSS class `popup` (permite estilo global desde `common/style.css`)
-- Header con icono (Nerd Font glyph) + título
-- Método `add(widget)` para añadir widgets al cuerpo
+- 320×400, no redimensionable, sin decoración
+- Clase CSS `popup`
+- Header con icono + título
+- `add(widget)` para el cuerpo
+- CSS: `churros.css` + `common.css` + el CSS del popup
 
 ---
 
 # Integration with Waybar
 
-Waybar invoca el launcher estable `/usr/bin/churros-popup` (script bash independizado del código Python). Ejemplos de `archiso/airootfs/etc/skel/.config/waybar/config.jsonc`:
+Ejemplos de `archiso/airootfs/etc/skel/.config/waybar/config.jsonc`:
 
 ```jsonc
 "network":      { "on-click": "churros-popup network" }
@@ -148,13 +95,12 @@ Waybar invoca el launcher estable `/usr/bin/churros-popup` (script bash independ
 "pulseaudio":   { "on-click": "churros-popup audio" }
 ```
 
-Acciones secundarias:
+Acciones secundarias de Waybar (no pasan por el popup):
 
-- `pulseaudio` → `on-click-right` silencia (`wpctl set-mute @DEFAULT_AUDIO_SINK@ toggle`)
-- `pulseaudio` → `on-scroll-up/down` ajusta volumen en 5%
-- `backlight` → `on-scroll-up/down` ajusta brillo `brightnessctl`
+- `pulseaudio` → click derecho silencia; scroll ajusta volumen
+- `backlight` → scroll ajusta brillo con `brightnessctl`
 
-Atajos de teclado en niri config.kdl:
+Atajos en niri:
 
 ```kdl
 Mod+Shift+N { spawn "churros-popup" "network"; }
@@ -165,76 +111,30 @@ Mod+Shift+T { spawn "churros-popup" "battery"; }
 Mod+Shift+E { spawn "churros-popup" "power"; }
 ```
 
-El Control Center (`/usr/bin/churros-control-center`) también lanza popups directamente vía `popup_launcher.py` (`subprocess.Popen([sys.executable, popup_main])`), sin pasar por el launcher de toggle — porque desde el control center cada clic abre una ventana nueva intencionalmente.
+El control center lanza el mismo binario (`churros-popup <nombre>`), no un `python3` por archivo.
 
 ---
 
 # Adding a New Popup
 
-1. Crea la carpeta del popup:
-
-   ```text
-   popups/<nombre>/
-   ```
-
-2. Implementa `main.py` (sigue el patrón de los popups existentes — añade `..` al `sys.path` para que `services.wifi`, `i18n` y otros módulos sean importables):
-
-   ```python
-   from pathlib import Path
-   import sys
-
-   sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
-
-   import gi
-   gi.require_version("Gtk", "4.0")
-   from gi.repository import Gtk
-
-   from window import MyWindow
-
-   class MyApp(Gtk.Application):
-       def do_activate(self):
-           window = MyWindow(self)
-           window.present()
-
-   app = MyApp()
-   app.run()
-   ```
-
-3. Implementa `window.py` extendiendo `PopupWindow`:
-
-   ```python
-   from common.popup import PopupWindow
-   from widgets.my_widget import MyWidget
-
-   class MyWindow(PopupWindow):
-       def __init__(self, app):
-           super().__init__(app, title="My Popup", icon="🧪")
-           self.add(MyWidget())
-   ```
-
-4. Crea `style.css` con los estilos del popup.
-
-5. Añade el nombre al case del launcher `/usr/bin/churros-popup`.
-
-6. Añade el módulo en Waybar (`on-click: "churros-popup <nombre>"`) o en un atajo de teclado de niri (`Mod+Shift+X { spawn "churros-popup" "<nombre>"; }`).
-
-Módulo i18n: el paquete `/usr/share/churros/i18n.py` está copiado en churros root y accessible con `from i18n import _` (gracias al `sys.path.insert(0, str(Path(__file__).resolve().parents[2]))` del `main.py`).
+1. Añade un módulo en `rust/popups/src/` que construya un `PopupWindow`.
+2. Regístralo en `build_window` y en el array `POPUPS` de `main.rs`.
+3. Añade CSS/iconos en `assets/` y en `archiso/airootfs/usr/share/churros/popups/assets/`.
+4. Enlázalo desde Waybar o niri.
 
 ---
 
 # Limitations
 
-- **Un solo popup a la vez**: el sistema está pensado para un popup activo. Intentar abrir dos da un comportamiento indefinido.
-- **Estado en `/tmp`**: al reiniciar se pierde. Esto es intencional: el popup debe reflejar el estado real del sistema, no cachear.
-- **Cierre manual**: los popups no se cierran automáticamente al perder foco. Hay que hacer clic fuera o matarlos con `pkill`.
-- **Sin tests**: la interacción con GTK4 hace difícil testear sin un display virtual. Los popups se prueban manualmente.
+- Un solo popup a la vez (intencional).
+- Estado en `/tmp`: al reiniciar se pierde.
+- No se cierran solos al perder el foco; Escape o toggle.
+- Sin tests automatizados GTK.
 
 ---
 
 # Future Work
 
-- Cierre automático al perder foco (con `focus-out` event o `wayland-popup`).
+- Cierre al perder foco.
 - Animaciones de entrada/salida.
-- Soporte para múltiples popups simultáneos (sidebar con widgets apilados).
-- Integración con la barra de notificaciones del sistema.
-- API común para que las apps externas puedan mostrar popups propios.
+- Varios popups a la vez (sidebar de widgets).

--- a/docs/preferences.md
+++ b/docs/preferences.md
@@ -1,591 +1,190 @@
 # Preferences
 
-`churros-settings` es la app de configuración principal de ChurrOS. Está escrita en Python + GTK4 con un estilo visual inspirado en System Settings de macOS pero con los colores naranja de ChurrOS.
+`churros-settings` es la app de configuración principal de ChurrOS. Está escrita en **Rust** (gtk4-rs) con un estilo visual inspirado en System Settings de macOS y los colores naranja de ChurrOS.
 
 ---
 
 # Overview
 
-**Path:** `archiso/airootfs/usr/share/churros/preferences/`
-**Launcher:** `/usr/bin/churros-settings` → `python3 /usr/share/churros/preferences/main.py`
+**Path:** `rust/preferences/`
+**Binario:** `/usr/bin/churros-settings` (desplegado por `build-rust.sh`)
 **Atajo:** `Mod + P` (niri)
+**Assets:** `/usr/share/churros/churros-settings/` en la ISO; `rust/preferences/assets/` en desarrollo
+**Log:** `/tmp/churros/churros-settings.log`
 
-La app tiene sidebar (páginas principales) + stack de páginas (con subpáginas navegables).
+Sidebar + stack de páginas (con subpáginas). Ventana por defecto 1280×760.
 
 ---
 
 # Estructura
 
 ```text
-preferences/
-├── main.py                  # PreferencesApplication (try/except en cada bloque)
-├── window.py                # PreferencesWindow (Gtk.ApplicationWindow + sidebar + stack)
-├── i18n.py                  # gettext wrapper (copia central)
-├── style.css                # CSS con variables (dark/light + accent)
-├── churros.css              # Stylesheet compartido (también usado por control-center y popups)
+rust/preferences/
+├── Cargo.toml                 # name = "churros-settings", deploy = true
 ├── assets/
-│   └── icons/               # SVGs del sidebar
-├── widgets/                 # Widgets base
-│   ├── page.py              # Page (ScrolledWindow + botón atrás opcional)
-│   ├── sidebar.py           # Sidebar con search + lista
-│   ├── navigator.py         # Navigator (Gtk.Stack con history, signal 'navigated')
-│   ├── row.py               # Row (Gtk.Button base, set_title/set_subtitle API)
-│   ├── group.py             # Group (card con separadores)
-│   ├── combo_row.py         # ComboRow (Gtk.Box — NO hereda de Button, evita capturar clicks)
-│   ├── slider_row.py        # SliderRow (Gtk.Scale + debounce opcional)
-│   ├── switch_row.py        # SwitchRow (Gtk.Switch)
-│   ├── select_row.py        # SelectRow (CheckButton group single-mutual)
-│   ├── color_picker.py      # ColorPickerRow (Acepta title, value, callback, subtitle)
-│   ├── search.py            # SearchEntry wrapper
-│   ├── dialog.py            # Dialogs genéricos (confirmación destructiva)
-│   ├── action_row.py        # ActionRow (botón derecho alineado)
-│   └── navigation_row.py    # NavigationRow (row con flecha a subpágina)
-├── services/                # Services (lógica del sistema)
-│   ├── settings.py          # SettingsService (JSON en ~/.config/churros/settings.json)
-│   ├── theme.py             # ThemeService (dark/light + recargas)
-│   ├── accent.py            # AccentService (genera accent.css con --accent-glow)
-│   ├── fonts.py             # FontService (gsettings + Gtk.Settings)
-│   ├── cursor.py            # CursorService (gsettings cursor-theme/size en vivo)
-│   ├── icons.py             # IconsService (gsettings icon-theme en vivo)
-│   ├── wallpaper.py         # WallpaperService (swaybg primero, awww fallback)
-│   ├── waybar.py            # WaybarService (config.jsonc + style.css liquid glass)
-│   ├── keyboard.py          # KeyboardService (parsea y edita binds de niri)
-│   ├── audio.py             # AudioService (wpctl/PipeWire)
-│   ├── power.py             # PowerService (powerprofilesctl, upower, gsettings)
-│   ├── display.py           # DisplayService + backends (niri/hyprland) + set_vrr()
-│   ├── datetime.py          # DatetimeService (timedatectl + churros-pkexec)
-│   ├── connectivity.py      # Wi-Fi + Bluetooth
-│   ├── about.py
-│   ├── system.py
-│   ├── users.py
-│   ├── privacy.py
-│   ├── pywal.py             # Integración con python-pywal
-│   ├── lock_screen.py       # swaylock + swayidle
-│   ├── night_light.py       # wlsunset
-│   ├── mako.py              # MakoService (config + reload + DND)
-│   ├── dotfiles/            # Editores de dotfiles (parseo KDL/JSONC)
-│   │   ├── niri_config.py   # NiriConfig (parser KDL path-based + reload())
-│   │   ├── foot_config.py
-│   │   ├── fuzzel_config.py
-│   │   └── ...
-│   └── backends/            # Backends de display
-│       ├── base.py
-│       ├── niri.py          # niri msg outputs/action
-│       └── hyprland.py      # hyprctl
-└── pages/                   # Páginas de la UI
-    ├── system.py
-    ├── appearance.py         # Padre con 9 grupos temáticos
-    ├── audio.py
-    ├── display.py            # VRR, resolución, brillo, scale
-    ├── connectivity.py
-    ├── power.py              # Padre de power-profile/battery/display-timeout/sleep
-    ├── users.py
-    ├── privacy.py
-    ├── about.py
-    ├── input.py              # Teclado/ratón
-    ├── datetime.py           # Fecha, hora, zona horaria (selector integrado), NTP
-    ├── keyboard.py           # Editor visual de atajos de Niri
-    ├── niri.py               # Animaciones, durations, toggles
-    ├── mako.py               # Notificaciones (DND, fuentes, bordes, disposición)
-    ├── night_light.py        # wlsunset (temperatura, gamma, automático)
-    ├── lock_screen.py        # swaylock/swayidle
-    ├── window_rules.py       # Reglas de ventana (window-rule blocks en KDL)
-    ├── logs.py               # Ver logs del sistema
-    ├── backup.py             # Exportar/importar/reset configuración
-    # Subpáginas de appearance
-    ├── accent.py
-    ├── icons.py
-    ├── cursor.py
-    ├── fonts.py
-    ├── wallpaper.py
-    └── waybar.py
-    # Subpáginas de power
-    ├── power_profile.py
-    ├── battery.py
-    ├── display_timeout.py
-    └── sleep.py
-    # Subpáginas de input
-    ├── foot.py               # Terminal
-    └── fuzzel.py             # Launcher
+└── src/
+    ├── main.rs                # Gtk.Application + carga de CSS
+    ├── window.rs              # PreferencesWindow (sidebar + stack + history)
+    ├── logging.rs
+    ├── assets.rs
+    ├── widgets/               # Page, Sidebar, Row, Group, ComboRow, …
+    ├── services/              # Settings, tema, acento, niri, mako, …
+    └── pages/                 # Una página por archivo
 ```
+
+Los servicios de display aún entienden un backend Hyprland (`hyprctl`) además de Niri; el escritorio oficial es Niri. Pywal está en la UI de Apariencia como interruptor, pero la integración real sigue en TODO.
 
 ---
 
 # Settings persistence
 
-`SettingsService` (`services/settings.py`):
+`SettingsService` (`services/settings.rs`):
 
 - Ruta: `~/.config/churros/settings.json`
-- Formato JSON anidado, acceso con dot keys: `SettingsService.get("theme.dark")`, `set("accent.color", "Orange")`.
-- Defaults definidos en `DEFAULTS` dict.
-- `_ensure()` crea el archivo con defaults la primera vez.
+- JSON anidado, acceso con dot keys (`theme.dark`, `accent.color`).
+- Defaults en código; crea el archivo la primera vez.
 
-outsourced a gsettings:
+También se espeja en gsettings:
 
-- `theme.dark` ↔ `org.gnome.desktop.interface color-scheme` (`prefer-dark` / `default`)
-- `cursor.theme` ↔ `org.gnome.desktop.interface cursor-theme`
-- `cursor theme size` ↔ `org.gnome.desktop.interface cursor-size`
-- `fonts.family` ↔ `org.gnome.desktop.interface font-name`, `document-font-name`, `monospace-font-name`
-- `fonts.scale` ↔ `org.gnome.desktop.interface text-scaling-factor`
-- `icons.theme` ↔ `org.gnome.desktop.interface icon-theme`
-
-`SettingsService` guarda su propia copia además para queries rápidas y para defaults offline.
+| Clave local | gsettings |
+|-------------|-----------|
+| `theme.dark` | `org.gnome.desktop.interface color-scheme` |
+| `cursor.theme` / tamaño | `cursor-theme` / `cursor-size` |
+| `fonts.family` / escala | `font-name`, `document-font-name`, `monospace-font-name`, `text-scaling-factor` |
+| `icons.theme` | `icon-theme` |
 
 ---
 
 # Tema (dark/light)
 
-`ThemeService.is_dark()`:
+`ThemeService`:
 
-1. Lee `theme.dark` del JSON local.
-2. Si no está, hace `gsettings get org.gnome.desktop.interface color-scheme` y cachea el resultado.
+1. Lee `theme.dark` del JSON; si no está, consulta gsettings y cachea.
+2. `set(dark)` persiste y escribe `prefer-dark` / `default`.
+3. La ventana añade o quita la clase `.light`. El CSS usa variables (`--bg-window`, `--text-primary`, …) definidas en `window` (oscuro) y `window.light`.
 
-`ThemeService.set(dark)`:
-
-1. Persiste en JSON local.
-2. Llama `gsettings set org.gnome.desktop.interface color-scheme prefer-dark|default`.
-3. La propia app Preferences detecta el cambio vía `Gio.Settings` `changed::color-scheme` signal y llama `_apply_theme_class()` (añade/quita `.light` en la ventana).
-
-El CSS se basa en variables (`--bg-window`, `--text-primary`, etc.) definidas en `window { ... }` (dark default) y sobrescritas en `window.light { ... }`. Cuando `.light` se añade al root, todas las reglas con `var(...)` reaccionan automáticamente.
-
-Importante: el CSS viejo tenía hardcodes `color:white` y 3 reglas conflictivas para `.sidebar`. El actual está limpio y todo usa `var(--*)`.
+En maximizado/fullscreen se añade la clase `maximized` para el CSS glass (menos blur).
 
 ---
 
 # Accent color
 
-`AccentService` (`services/accent.py`):
+`AccentService` — 8 colores (Blue, Purple, Pink, Red, Orange, Yellow, Green, Teal).
 
-- 8 colores predefinidos: Blue, Purple, Pink, Red, Orange, Yellow, Green, Teal.
-- `current()` lee `accent.color` del JSON.
-- `set(color)`:
-  1. Persiste en JSON.
-  2. Genera `~/.config/churros/accent.css` con variables `--accent`, `--accent-strong`, `--accent-soft`, `--accent-bg-hover`, `--accent-text`.
-  3. Usa `colorsys` para derivar variantes (strong = darker, soft = lighter).
-
-Importante GTK4: el CSS generado usa `window { ... }` (NO `:root` — GTK4 no lo soporta).
-
-`AccentPage._reload_accent_css()` recarga el archivo en runtime:
-
-```python
-provider = Gtk.CssProvider()
-provider.load_from_path(accent_css)
-Gtk.StyleContext.add_provider_for_display(
-    Gdk.Display.get_default(),
-    provider,
-    Gtk.STYLE_PROVIDER_PRIORITY_USER + 1   # prioridad mayor al style.css principal
-)
-```
-
-Resultado: clic en "Green" → recarga CSS → todos los `var(--accent)` se actualizan.
+`set(color)` escribe `~/.config/churros/accent.css` con `--accent` y variantes. El CSS usa `window { … }` (GTK4 no soporta `:root`). Se recarga en caliente con un `CssProvider` a prioridad USER.
 
 ---
 
-# Fuentes
+# Fuentes, cursor, iconos, wallpaper
 
-`FontService` (`services/fonts.py`):
-
-- `available()` — lista familias vía `fc-list : family`.
-- `current()` — JSON local (`fonts.family`).
-- `set(family)` — además de gsettings (`font-name`, `document-font-name`, `monospace-font-name`), llama `Gtk.Settings.get_default().set_property("gtk-font-name", ...)` para que la app actual reaccione sin reiniciar. También resetea `gtk-fontconfig-timestamp` para forzar reload de fontconfig.
-- `scale()` / `set_scale(scale)` — `text-scaling-factor` en gsettings + `gtk-xft-dpi` en Gtk.Settings.
+- **FontService** — `fc-list`, gsettings + `Gtk.Settings` (`gtk-font-name`, `gtk-xft-dpi`) para que la propia app reaccione sin reiniciar.
+- **CursorService** — busca temas en `/usr/share/icons` y `~/.icons`; aplica `cursor-theme` / `cursor-size`.
+- **IconsService** — `icon-theme` en gsettings.
+- **WallpaperService** — `swaybg` (con fallback). El hook pywal está pendiente.
 
 ---
 
-# Cursor
+# Display
 
-`CursorService` (`services/cursor.py`):
-
-- `available()` — busca en `/usr/share/icons`, `~/.icons`, `~/.local/share/icons` las carpetas con subdirectorio `cursors/`.
-- `current()` — gsettings `cursor-theme`.
-- `set(theme)` — gsettings + JSON local.
-- `size()` / `set_size(px)` — gsettings `cursor-size`.
-
-`CursorPage` además incluye un SliderRow (8–64 px) para el tamaño.
+`DisplayService` lista monitores y modos. Backend principal: `niri msg outputs` / `niri msg action`. Queda un backend Hyprland (`hyprctl monitors -j`) por si `XDG_CURRENT_DESKTOP` lo indica; no implementa VRR ni cambio de resolución (la página omite esos controles en ese caso).
 
 ---
 
-# Wallpaper
+# Navegación
 
-`WallpaperService` (`services/wallpaper.py`):
-
-Dirs buscadas (en orden):
-
-- `~/.local/share/churros/wallpapers/` (USER_DIR, donde se copian las importadas)
-- `/usr/share/churros/wallpapers/`
-- `/usr/share/backgrounds/`
-- `~/Pictures/Wallpapers/`
-- `~/Pictures/`
-
-Extensões: `.jpg`, `.jpeg`, `.png`, `.webp`, `.gif`.
-
-`set(path)`:
-
-1. Persiste `wallpaper.path` en JSON.
-2. Intenta con `awww img <path>` (transiciones suaves). Si `awww-daemon` no está corriendo, lo arranca.
-3. Si `awww` no existe o falla → fallback a `pkill swaybg` + `swaybg -i path -m fill` (start_new_session=True para que sobreviva a la app).
-
-`import_image(source_path)`:
-
-- Copia cualquier imagen del disco del usuario a `~/.local/share/churros/wallpapers/`.
-- Maneja renombres si el nombre ya existe (`foto_1.png`, `foto_2.png`, …).
-- Devuelve la ruta destino, o None si falla.
-
-`WallpaperPage` UI:
-
-- Botón "Importar desde archivos..." usando `Gtk.FileDialog` (GTK4 nativo, no el deprecated FileChooserDialog).
-- Filtro de mime types: image/jpeg, image/png, image/webp, image/gif.
-- Ruta inicial: `~` (Gio.File.new_for_path).
-- Miniatura del fondo actual (160px, con clase `wallpaper-preview`).
-- `Gtk.FlowBox` con thumbnails (120px cada uno) de todos los disponibles. El actual tiene clase `wallpaper-selected` (border accent).
-- Tras importar: copia → aplica → recarga todo el grid (`_rebuild_grid()`).
-
-CSS:
-
-- `.wallpaper-thumb` — thumbnail base (radius 10px).
-- `.wallpaper-selected` — 3px border accent.
-- `.wallpaper-button:hover` — border accent al hover.
-
-## Theme連動 (Modo oscuro/claro)
-
-`ThemeService.set(dark)` (en `services/theme.py`):
-
-1. Persiste `theme.dark` en JSON local.
-2. Llama `_write_gtk_settings(dark)` que escribe `~/.config/gtk-{3,4}.0/settings.ini` con `gtk-theme-name` y `gtk-application-prefer-dark-theme`.
-3. **Cambia el wallpaper automáticamente**:
-   - Dark → `/usr/share/churros/wallpapers/fondo1.png`
-   - Light → `/usr/share/churros/wallpapers/default.jpeg`
-4. Envía `SIGUSR2` a waybar (recarga) y a foot `SIGUSR1`/`SIGUSR2` según el modo (oscuro/claro).
-
-`WallpaperService.apply(path)`:
-
-1. Llama `churros-apply-wallpaper` (wrapper bash).
-2. Wrapper prueba en orden: `swaybg` → `awww` (si falla).
-3. Al final del apply, ejecuta `niri msg action do-screen-transition` para forzar repintura en Niri.
-4. Fallback inline en Python si el wrapper no existe.
-
-## Waybar (subpágina de Apariencia)
-
-`WaybarService` (`services/waybar.py`):
-
-- `DEFAULTS`: layer=top, position=top, height=30, spacing=0, font-size=14, font-family="JetBrainsMono Nerd Font", background=#2a1612, foreground=#c9c4c3, accent=#DE8636, background-alpha=0.9.
-
-- `get()` — lee config.jsonc + colors-waybar.css.
-
-- `set(values)`:
-  1. Escribe `~/.config/waybar/config.jsonc` (preserva definiciones de módulos del skel).
-  2. Escribe `~/.config/waybar/colors-waybar.css` con `@define-color` para `background`, `foreground`, `color4`, `color1`. **Nunca** `@define-color background-alpha` con número — waybar crashea con `'0' is not a valid color name`.
-  3. Escribe `~/.config/waybar/style.css` con liquid glass: ventana transparente, workspaces con pill translúcido + items activos en naranja, hover states.
-  4. Llama `reload()` que mata waybar (`pkill -x waybar`), espera 1s, verifica que murió (`pgrep`), lanza nuevo `waybar`.
-
-- `reload()` loguea a `/tmp/waybar.log` para debugging.
-
-`WaybarPage` UI:
-
-- Sliders para altura (20-80), espaciado (0-16), font-size (10-24).
-- Combo para capa (top/overlay/bottom) y posición (top/bottom/left/right).
-- Color pickers para fondo, texto, acento.
-- **Sistema de rotación de módulos** (sin popovers — GTK4 Popover no funciona en Niri):
-  - Click izquierdo en un módulo → rota posición left → center → right → left.
-  - Click derecho → quita el módulo.
-- Botones "Recargar waybar" y "Restablecer defaults".
-
-## Keyboard (Atajos de teclado)
-
-`KeyboardService` (`services/keyboard.py`):
-
-- Lee/escribe `~/.config/niri/config.kdl` directamente.
-- `get_keybinds()` — parsea el bloque `binds { ... }` con regex.
-- `set_keybind(key, action_type, command, args)` — reemplaza un binding existente.
-- `add_keybind(key, action_type, command, args)` — añade un nuevo binding antes del `}` de cierre.
-- `restore_backup()` — restaura desde `config.kdl.bak`.
-
-Backup automático antes de cada escritura en `NIRI_CONFIG_BACKUP`.
-
-`KeyboardPage` UI:
-
-- Agrupa atajos en categorías: Aplicaciones, Ventanas, Workspaces, Movimiento, Capturas, Overlays, Multimedia, Niri.
-- **Click en un atajo** abre diálogo de edición que muestra:
-  - Atajo actual y acción actual (resaltados).
-  - Campo "Nuevo atajo" (placeholder: `Ej: Mod+Shift+X`).
-  - Campo "Nuevo comando" (pre-rellenado).
-  - Campo "Argumentos" (pre-rellenado).
-- Botón **"Agregar nuevo atajo"** al inicio para crear atajos nuevos con campos vacíos.
-- Al guardar, rebuild automático de la lista.
-
-## DateTime (Fecha y hora)
-
-`DateTimePage` (sin service dedicado, usa `timedatectl` directamente):
-
-- Estado actual: hora, fecha, zona horaria, RTC.
-- "Sincronizar hora con internet" → `sudo timedatectl set-ntp true` en foot.
-- "Cambiar zona horaria" → selector interactivo con `fzf` sobre `timedatectl list-timezones` o fallback `less`.
+- `gtk::Stack` + historial en `window.rs`.
+- `Ctrl+F` enfoca la búsqueda global; salta a subpáginas y resalta el row.
+- `Alt+Left` o el botón atrás vuelven en el historial.
+- En pantallas estrechas el sidebar se colapsa (`Revealer`).
+- El item del sidebar sigue al padre si estás en una subpágina.
 
 ---
 
-# Power
+# Árbol de páginas
 
-Métodos de lectura:
+`power` es padre de power-profile / battery / display-timeout / sleep. `appearance` agrupa acento, iconos, cursor, fuentes, wallpaper y waybar.
 
-- `battery_present()` — `upower -e` busca un dispositivo que termine en `battery`.
-- `battery_percentage()` — `upower -i /org/freedesktop/UPower/devices/battery_BAT0` (fallback BAT1).
-- `battery_state()` — `charging`, `discharging`, `full`, etc.
-- `power_profile()` — `powerprofilesctl get` (performance/balanced/power-saver).
-- `power_profiles_available()` — `powerprofilesctl list`.
-- `screen_timeout()` / `sleep_timeout()` — gsettings `idle-delay` / `sleep-inactive-ac-timeout`.
-- `lid_close_action()` — gsettings `lid-close-ac-action`.
-
-Setters:
-
-- `set_power_profile(profile)`.
-- `set_screen_timeout(seconds)`.
-- `set_sleep_timeout(seconds)`.
-- `set_lid_close_action(action)`.
-
-Páginas:
-
-- `power.py` — menú con NavigationRows a las 4 subpáginas.
-- `power_profile.py` — combo performance/balanced/power-saver con labels localizados.
-- `battery.py` — estado real (upower) o mensaje "No se detecta ninguna batería".
-- `display_timeout.py` — combo "1m/2m/5m/10m/15m/30m/Nunca".
-- `sleep.py` — combo timeout + combo acción al cerrar tapa.
-
-Todas las subpáginas llevan `parent_page="power"` para mostrar el botón "Atrás".
-
----
-
-# Display backends
-
-`services/backends/` define `DisplayBackend` (clase abstracta) con dos implementaciones:
-
-- `niri.py` — vía `niri msg action ...` y `niri msg output ...`. Soporta `set_resolution`, `set_vrr`, `set_scale`, `set_rotation`, `set_brightness`.
-- `hyprland.py` — vía `hyprctl keyword monitor ...`. NO soporta `set_resolution` ni `set_vrr` (stubs que devuelven False), solo `set_scale`, `set_rotation` y brightness.
-
-`DisplayService.backend()` autodetecta el compositor activo.
-
-`DisplayPage` comprueba `backend.supports_resolution()` y `backend.supports_vrr()` antes de mostrar los combos correspondientes. Si el backend no soporta VRR, no se muestra el switch "Frecuencia variable (VRR)".
-
-Bug histórico: `on_vrr(self, switch, active)` recibía 2 args cuando `SwitchRow` solo pasa 1 (el bool). Corregido a `on_vrr(self, active)`.
-
----
-
-# Subpáginas y navegación
-
-`Navigator` (`widgets/navigator.py`) es un `Gtk.Stack` con:
-
-- `add_page(name, widget)` — añade una página al stack (si no existe ya).
-- `show_page(name)` — muestra la página, metiendo la anterior en `self.history`.
-- `back()` — pop del historial.
-- `clear_history()`.
-
-`Page` (`widgets/page.py`) es un `Gtk.ScrolledWindow` que acepta `parent_page=None`:
-
-- Si se pasa `parent_page`, añade un botón "Atrás" (icon `go-previous-symbolic`) al inicio.
-- `on_back()` llama `navigator.show_page(self.parent_page)`.
-
-Subpáginas registradas en `window.py`:
-
-```
-appearance (padre) → accent, icons, cursor, fonts, wallpaper
-power     (padre) → power-profile, battery, display-timeout, sleep
-```
-
-Cada subpágina declara `parent_page="appearance"` o `parent_page="power"` en su `super().__init__(...)`.
-
----
-
-# SelectRow — selección single mutual
-
-`SelectRow` (`widgets/select_row.py`) hereda de `Row` (Gtk.Button) y añade un `Gtk.CheckButton` como suffix.
-
-Problemas que tuvo:
-
-- En GTK4 el `Gtk.Button` captura el click y el `CheckButton` hijo no recibe el evento → el callback no se ejecutaba.
-- Multiple rows activos sin group → varios items quedaban seleccionados.
-
-Fix actual:
-
-- `Gtk.CheckButton.set_group()` con group compartido (atributo de clase `SelectRow.group`).
-- Callback conectado a `notify::active` del CheckButton (se emite SIEMPRE al togglear).
-- `on_row_clicked` fuerza `set_active(True)` para que el grupo se re sincronice desde el click del row.
-- `SelectRow.reset_group()` class method — llamarlo al inicio del `__init__` de cada página que use SelectRow (accent, cursor, icons) para que cada página tenga su propio grupo.
-
----
-
-# CSS — Estilo macOS con colores ChurrOS
-
-`style.css` (~460 líneas):
-
-Tokens en `window { ... }` (dark default):
-
-```css
---bg-window:        rgba(30,30,32,.96);
---bg-sidebar:       rgba(42,42,46,.78);
---bg-group:         rgba(56,56,60,.55);
---text-primary:     rgba(255,255,255,.96);
---text-secondary:   rgba(255,255,255,.55);
---border-soft:      rgba(255,255,255,.08);
---accent:           #DE8636;        /* ChurrOS naranja */
---accent-soft:      #E6A56A;
---accent-strong:    #B86A24;
---accent-text:      #ffffff;
---accent-bg-hover:  rgba(222,134,54,.18);
---scroller-thumb:  rgba(255,255,255,.12);
-```
-
-Override `window.light { ... }`:
-
-```css
---bg-window:        rgba(242,242,245,.98);
---bg-sidebar:       rgba(232,232,236,.85);
---bg-group:         rgba(255,255,255,.92);
---text-primary:     rgba(28,28,30,.96);
---text-secondary:   rgba(28,28,30,.60);
---border-soft:      rgba(0,0,0,.08);
---accent:           #C5651C;        /* más oscuro para contraste en fondo claro */
-```
-
-Estilo macOS:
-
-- Sidebar translúcido (alpha < 1), radius 16px, border subtle.
-- Items sidebar: radius 9px, hover en accent-bg-hover, activo con fondo accent sólido + texto accent-text.
-- Search box con radius 9px, focus border en accent.
-- Grupos tipo card: radius 12px, border soft.
-- Rows: radius 8px, hover en row-bg-hover. Son Gtk.Button sin frame.
-- Group title: small caps, accent o text-secondary.
-- Switches estilo iOS: 42x24 con border-radius 14px, slider 18x18 que se desplaza 22px al activar.
-- Sliders con trough 5px y slider 14px redondo con sombra.
-- DropDowns (combos) con radius 8px y hover en accent.
-- Popover list rows con radius 6px.
-- Scrollbar fina 8px, color scroller-thumb, hover en accent.
-- About card radius 16px.
-- Wallpaper thumbs radius 10px, selected 3px border accent.
-- Back button radius 8px.
-
-Sin reglas duplicadas, sin hardcodes fuera de los tokens.
-
----
-
-# Build pipeline
-
-`preederences/main.py` al arrancar:
-
-1. `AccentService.ensure()` — si `~/.config/churros/accent.css` no existe, lo genera.
-2. Carga `style.css` con `Gtk.CssProvider.load_from_path` y registra con `Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION`.
-3. Si existe `~/.config/churros/accent.css`, lo carga con prioridad `Gtk.STYLE_PROVIDER_PRIORITY_USER` (mayor que el style.css principal, así `--accent` del override gana).
-4. Crea `PreferencesWindow(self)` y la presenta.
-
-CSS reload tras cambio de accent:
-
-- `AccentPage._reload_accent_css()` crea un provider nuevo con prioridad `Gtk.STYLE_PROVIDER_PRIORITY_USER + 1` (aún mayor) para que las nuevas variables ganen.
-
----
-
-# Atajos globales de teclado
-
-`PreferencesWindow` registra atajos globales en `window.py` (vía `Gtk.EventControllerKey`):
-
-| Atajo | Acción |
-|-------|--------|
-| `Ctrl+F` | Foco al search del sidebar |
-| `Ctrl+B` | Toggle sidebar narrow (sólo iconos) |
-| `Shift+Ctrl+N` | Toggle sidebar narrow (alias) |
-
-El sidebar narrow oculta los labels dejando sólo los iconos — útil para pantallas pequeñas.
-
----
-
-# Robustez y logs
-
-La app está blindada contra fallos:
-
-- `churros-settings` (script bash): redirige output a log en `$XDG_RUNTIME_DIR/churros-settings.log` (fallback `/tmp/churros-settings.log`). Autodetecta `WAYLAND_DISPLAY` si no está exportado. Si `churros-settings` falla por completo, no aborta la sesión del usuario — el último error queda en el log.
-- `main.py`: cada bloque crítico (`_build_wallpaper`, constructores de páginas) envuelto en try/except. Los errores se loguean con stack trace completo a `$XDG_RUNTIME_DIR/churros-settings.log`.
-- `ColorPickerRow` (`e517f4f`): ahora acepta el kwarg `subtitle` para integrarse en `LockScreenPage` y otras páginas donde el color picker vive dentro de un Row con descripción secundaria.
-- `ComboRow` (`e1c2477`): reescrito como `Gtk.Box` directo. Antes heredaba de `Gtk.Button` que capturaba los clicks del dropdown. Bug se manifestaba al pulsar la flecha del combo — el botón padre absorbía el evento.
-
-Reload sin reinicio:
-
-- `NiriConfig.reload()` envía `pkill -HUP niri` (SIGUSR2 re-reload completo; SIGUSR1 sólo para la config de monitor). Algunos cambios de Niri (animations toggle, durations) ya no requieren cerrar la app — se aplican al instante.
-- `MakoService.reload()` ejecuta `makoctl reload` tras modificar el config.
-- `WaybarService.reload()` envía `SIGUSR1` a waybar (recarga sin perder estado).
-- `ThemeService` y `AccentService` regeneran CSS y notifican a niri/waybar/foot.
+| Página | Sección | Función |
+|--------|---------|---------|
+| `system.rs` | Sistema | Hostname, kernel, OS |
+| `appearance.rs` | Apariencia | Padre (tema, pywal stub, 9 grupos) |
+| ↳ `accent.rs` | (subpágina) | 8 colores + custom |
+| ↳ `icons.rs` | (subpágina) | Tema de iconos |
+| ↳ `cursor.rs` | (subpágina) | Tema y tamaño de cursor |
+| ↳ `fonts.rs` | (subpágina) | Familia, escala, preview |
+| ↳ `wallpaper.rs` | (subpágina) | Selector de fondo |
+| ↳ `waybar.rs` | (subpágina) | Posición, módulos, colores |
+| `display.rs` | Pantalla | Resolución, brillo, scale, VRR |
+| `audio.rs` | Sonido | Volumen, dispositivo |
+| `mako.rs` | Notificaciones | DND, tipografía, colores, bordes |
+| `night_light.rs` | Pantalla | `wlsunset` |
+| `lock_screen.rs` | Pantalla | `swaylock` / `swayidle` |
+| `connectivity.rs` | Red | Wi-Fi, ethernet, bluetooth |
+| `power.rs` | Energía | Padre |
+| ↳ `power_profile.rs` | (subpágina) | `powerprofilesctl` |
+| ↳ `battery.rs` | (subpágina) | Estado y umbrales |
+| ↳ `display_timeout.rs` | (subpágina) | Apagado de pantalla |
+| ↳ `sleep.rs` | (subpágina) | Suspensión y tapa |
+| `datetime.rs` | Sistema | Reloj, zona horaria, NTP |
+| `niri.rs` | Sistema | Animaciones y duraciones |
+| `window_rules.rs` | Sistema | Bloques `window-rule {}` |
+| `keyboard.rs` | Entrada | Atajos de Niri |
+| `input.rs` | Entrada | Teclado / ratón |
+| `foot.rs` | Entrada | `foot.ini` |
+| `fuzzel.rs` | Entrada | `fuzzel.ini` |
+| `applications.rs` | Sistema | Apps instaladas |
+| `users.rs` | Sistema | Cuentas |
+| `privacy.rs` | Sistema | Permisos |
+| `backup.rs` | Sistema | Export / import / reset de `~/.config/churros/` |
+| `logs.rs` | Sistema | Visor de logs |
+| `about.rs` | Sistema | Versión, créditos, licencia |
 
 ---
 
 # Servicios extra
 
-- **`PywalService`** (`services/pywal.py`) — Hook para `python-pywal`. Cuando está activo en `Apariencia`, genera paleta de 16 colores desde el wallpaper actual y los aplica como `--accent` y variables derivadas. Se desactiva con un click.
-- **`LockScreenService`** (`services/lock_screen.py`) — Wrapper sobre `swaylock` y `swayidle`. Habilita/deshabilita el lock automático con timeout configurable, lock al suspender, comandos previos al lock (v.gr. `wlsunset -t 3500`).
-- **`NightLightService`** (`services/night_light.py`) — Wrapper sobre `wlsunset`. Control de temperatura (3000K–6000K), gamma, modo automático basado en latitud/horario.
-- **`MakoService`** (`services/mako.py`) — Lee/escribe `~/.config/mako/config`, ejecuta `makoctl reload` tras cambios, toggle DND (`makoctl mode -a/-r do-not-disturb`).
+- **LockScreenService** — `swaylock` + `swayidle` (timeout, lock al suspender).
+- **NightLightService** — `wlsunset` (temperatura, gamma, automático).
+- **MakoService** (`mako_config.rs`) — escribe `~/.config/mako/config`, `makoctl reload`, DND.
+- **NiriConfig** — parser KDL y `reload()` (`pkill -HUP niri`).
+- **WaybarService** — `config.jsonc` + `style.css`; recarga con `SIGUSR1`.
+- **DatetimeService** — `timedatectl` vía `churros-pkexec`.
+- **BackupService** — tar de `~/.config/churros/`.
 
 ---
 
-# Páginas — referencia rápida
+# Robustez
 
-Cada página de `churros-settings` se registra en `window.py` y se mapea a un archivo en `pages/`. Las páginas se agrupan en la sidebar por sección. Las páginas marcadas con **(subpágina)** sólo son accesibles vía la página padre o el search global.
+- `logging.rs` escribe a `/tmp/churros/churros-settings.log` y captura panics.
+- Recargas sin reiniciar la app: Niri (HUP), Mako (`makoctl reload`), Waybar (`SIGUSR1`), tema y acento (CSS en caliente).
+- `ComboRow` es un `Gtk.Box` (no hereda de `Button`, para no comerse los clics del dropdown).
 
-| Página | Sección | Función |
-|--------|---------|---------|
-| `system.py` | Sistema | Nombre de host, kernel, OS info |
-| `appearance.py` | Apariencia | Padre con 9 grupos temáticos |
-| ↳ `accent.py` | (subpágina) | Selector de acento (8 colores + custom) |
-| ↳ `icons.py` | (subpágina) | Tema de iconos + tamaño |
-| ↳ `cursor.py` | (subpágina) | Tema de cursor + tamaño |
-| ↳ `fonts.py` | (subpágina) | Familia de fuentes + tamaño + preview |
-| ↳ `wallpaper.py` | (subpágina) | Selector de wallpaper (live preview) |
-| ↳ `waybar.py` | (subpágina) | Posición, módulos, colores, transparencia |
-| `display.py` | Pantalla | Resolución, brillo, scale, VRR |
-| `audio.py` | Sonido | Volumen, dispositivo, perfil |
-| `mako.py` | Notificaciones | DND, tipografía, colores, bordes, padding |
-| `night_light.py` | Pantalla | `wlsunset` (temperatura, gamma, auto) |
-| `lock_screen.py` | Pantalla | `swaylock`/`swayidle` (timeout, suspend lock, fondo) |
-| `connectivity.py` | Red | Wi-Fi, ethernet, bluetooth |
-| `power.py` | Energía | Padre de perfiles/timeout/sleep/batería |
-| ↳ `power_profile.py` | (subpágina) | `powerprofilesctl` (Performance/Balanced/Power-Saver) |
-| ↳ `battery.py` | (subpágina) | Umbrales de carga (charge thresholds) |
-| ↳ `display_timeout.py` | (subpágina) | Apagado automático de pantalla |
-| ↳ `sleep.py` | (subpágina) | Timeout de suspensión + lid close |
-| `datetime.py` | Sistema | Reloj vivo, zona horaria (selector integrado), NTP |
-| `niri.py` | Sistema | Animaciones toggle, durations |
-| `window_rules.py` | Sistema | Editor visual de `window-rule {}` blocks |
-| `keyboard.py` | Entrada | Editor de atajos de Niri |
-| `input.py` | Entrada | Teclado/ratón (repetición, velocidad) |
-| `foot.py` | Entrada | Editor de dotfile `foot.ini` |
-| `fuzzel.py` | Entrada | Editor de dotfile `fuzzel.ini` |
-| `users.py` | Sistema | Cuentas de usuario |
-| `privacy.py` | Sistema | Permisos y telemetría |
-| `backup.py` | Sistema | Export/import/reset de `~/.config/churros/` |
-| `logs.py` | Sistema | Visor de logs del sistema |
-| `about.py` | Sistema | Versión, créditos, licencia |
+---
 
-### Búsqueda global
+# Atajos globales
 
-`Ctrl+F` enfoca la búsqueda. Buscar por nombre de página ("waybar"), por acción ("modo oscuro", "DND"), por componente ("zsh", "firefox") salta a la página correspondiente. Si el término matchea dentro de una subpágina, navega al padre y resalta el row.
-
-### Navegación
-
-- `Navigator` (stack con history) emite `navigated` cuando cambia la página visible.
-- `PreferencesWindow` sincroniza el item del sidebar — si estás en `accent.py` (subpágina) el item resaltado es `Apariencia` (padre).
-- Click en `← Atrás` (en pages con history) o `Alt+Left` revierte.
+| Atajo | Acción |
+|-------|--------|
+| `Ctrl+F` | Búsqueda |
+| `Alt+Left` | Atrás |
+| `Mod+P` | Abrir la app (niri) |
 
 ---
 
 # Known limitations
 
-- **font-name y gtk**: el cambio de fuente se refleja inmediatamente solo en la app Preferences actual. Otras apps GTK respawn lo aplican automáticamente (gsettings func); para apps ya corriendo hay que esperar reload o reiniciarlas.
-- **i18n gettext**: actualmente `i18n._()` solo devuelve la string original (no carga PO/MO files). La infraestructura está lista; solo falta compilar `po/churros.po` a `/usr/share/locale/es/LC_MESSAGES/churros.mo`.
-- **Multi-monitor display page**: DisplayPage asume un solo monitor; multi-monitor requiere refactor del `Monitor` model.
-- **Hyprland backend supports_* stubs**: hyprland backend no implementa VRR ni set_resolution (devuelven False). DisplayPage omite esos combos cuando está activo.
-- **Tests**: sin tests automatizados GTK4; verificación es `python3 -c "import ast; ast.parse(open(f).read())"` para todos los .py + lanzar manualmente cada app en niri.
+- El cambio de fuente se aplica al momento en esta app; otras GTK ya abiertas pueden necesitar reinicio.
+- i18n: los `.po` existen, pero el binario Rust aún no carga gettext.
+- Display asume un monitor principal; multi-monitor incompleto.
+- Backend Hyprland: sin VRR ni `set_resolution`.
+- Pywal: interruptor visible, integración pendiente.
+- Sin tests automatizados GTK. Verificación: `cargo build` + probar en niri / `./churros run`.
 
 ---
 
 # Future work
 
-- Soporte multi-monitor en DisplayPage.
-- Dynamic colors: `theme.dynamic_colors` flag existe en settings.json pero no tiene efecto todavía. Idea: usar `python-pywal` para generar `~/.cache/wal/colors.css` desde el wallpaper actual y aplicar como `--accent` derivado.
-- Per-user cursor/wallpaper persistence entre sesiones (gsettings es per-user, settings.json también).
-- Página de input avanzada: gesture del trackpad, natural scrolling, tap-and-drag.
-- Aplicar font/cursor a Qt apps (env vars QT_QPA_FONTDIR, etc.).
+- Multi-monitor en Display.
+- Terminar pywal (`theme.dynamic_colors`).
+- Gestos de trackpad y scrolling natural.
+- Aplicar fuente/cursor a apps Qt.

--- a/docs/services.md
+++ b/docs/services.md
@@ -1,65 +1,47 @@
 # Services
 
-Este documento describe los servicios del sistema que utilizan las aplicaciones oficiales de ChurrOS.
+Este documento describe la capa de servicios que usan las apps oficiales.
 
-Los servicios son módulos Python que envuelven comandos del sistema y exponen una API uniforme a las apps GTK4 (control center, popups, widgets). Toda la interacción con el hardware y los servicios del sistema (audio, batería, red, brillo, energía) pasa por aquí.
+`churros_services` es un crate Rust (`rust/services/`, `deploy = false`) que envuelve comandos del sistema y expone una API uniforme. Lo consumen `churros-popup` y `churros-control-center`. Preferencias tiene además sus propios servicios de dotfiles y settings en `rust/preferences/src/services/`.
+
+El código Python de `usr/share/churros/services/` ya no está en el repositorio.
 
 ---
 
 # Overview
 
-Todos los servicios viven en:
-
 ```text
-archiso/airootfs/usr/share/churros/services/
+rust/services/src/
+├── lib.rs          # run / spawn / which
+├── audio.rs        # wpctl
+├── battery.rs      # upower
+├── bluetooth.rs    # bluetoothctl / rfkill
+├── brightness.rs   # brightnessctl + /sys/class/backlight
+├── ethernet.rs     # nmcli
+├── power.rs        # loginctl, niri msg, systemctl
+└── wifi.rs         # nmcli
 ```
 
-Cada servicio es una clase con métodos estáticos. El patrón común es:
+Patrón:
 
-- `get()` — devuelve un diccionario con el estado actual
-- `set(value)` — aplica un cambio
-- Métodos auxiliares (`enable`, `disable`, `toggle`, `lock`, `logout`, etc.) según el servicio
-
-Ningún servicio tiene estado interno: cada llamada lee del sistema en tiempo real. Esto simplifica el código y permite que múltiples widgets o popups consulten el mismo dato sin coordinarse.
-
-Los servicios no se importan directamente desde las apps: se accede a ellos desde los widgets de cada app. Por ejemplo, el popup de audio importa `services/audio.py` desde `archiso/airootfs/usr/share/churros/services/`.
+- Funciones libres (no hay clases estáticas).
+- `get()` / `available()` leen el sistema en el momento.
+- `run(cmd, timeout_ms)` captura stdout/stderr; `spawn` es fire-and-forget.
+- Sin estado interno: cada llamada refleja el hardware actual.
 
 ---
 
-# Common Pattern
+# Common helpers
 
-```python
-import subprocess
+```rust
+pub type RunOut = (i32, String, String);
 
-
-class AudioService:
-
-    @staticmethod
-    def get_volume():
-
-        output = subprocess.check_output(
-            ["wpctl", "get-volume", "@DEFAULT_AUDIO_SINK@"],
-            text=True
-        )
-
-        volume = float(output.split()[1])
-
-        return int(volume * 100)
-
-    @staticmethod
-    def set_volume(value):
-
-        subprocess.run(
-            [
-                "wpctl",
-                "set-volume",
-                "@DEFAULT_AUDIO_SINK@",
-                f"{value}%"
-            ]
-        )
+pub fn run(cmd: &[&str], timeout_ms: u64) -> Option<RunOut>;
+pub fn spawn(cmd: &[&str]);
+pub fn which(bin: &str) -> bool;
 ```
 
-Todas las clases siguen esta forma. La salida de `get()` siempre es un dict plano con campos predecibles; `set()` siempre es síncrono y no devuelve nada.
+`run` devuelve `None` si falla el spawn, hay timeout o la salida no es UTF-8.
 
 ---
 
@@ -67,206 +49,104 @@ Todas las clases siguen esta forma. La salida de `get()` siempre es un dict plan
 
 ## audio
 
-**Archivo:** `archiso/airootfs/usr/share/churros/services/audio.py`
+Wrapper sobre `wpctl` (PipeWire). Opera sobre `@DEFAULT_AUDIO_SINK@` / `@DEFAULT_AUDIO_SOURCE@`.
 
-Wrapper sobre `wpctl` (PipeWire).
+| Función | Acción |
+|---------|--------|
+| `get_volume()` / `set_volume(value)` | Volumen de salida 0–100 |
+| `is_muted()` / `set_mute(muted)` | Mute de salida |
+| `get_input_volume()` / `set_input_volume` | Entrada |
+| `list_sinks()` / `list_sources()` | Dispositivos (`AudioDevice { id, name, default }`) |
+| `set_default_sink(node_id)` | Cambiar sink |
 
-| Método | Comando | Devuelve |
-|--------|---------|----------|
-| `get_volume()` | `wpctl get-volume @DEFAULT_AUDIO_SINK@` | int (0–100) |
-| `set_volume(value)` | `wpctl set-volume @DEFAULT_AUDIO_SINK@ <value>%` | — |
-
-No usa `sinks` por nombre: siempre opera sobre `@DEFAULT_AUDIO_SINK@`, que PipeWire resuelve en tiempo de ejecución. Esto evita problemas cuando el usuario cambia de dispositivo de salida.
-
-Usado por:
-
-- Popup de audio (volumen + mute + dispositivo)
-- Waybar (módulo `pulseaudio` con scroll y click derecho)
-- Control center (tarjeta de audio)
+Usado por el popup de audio, Waybar (`pulseaudio`) y el control center.
 
 ---
 
 ## battery
 
-**Archivo:** `archiso/airootfs/usr/share/churros/services/battery.py`
-
 Wrapper sobre `upower`.
 
-| Método | Comando | Devuelve |
-|--------|---------|----------|
-| `get()` | `upower -e` + `upower -i <device>` | dict |
+`get()` → `BatteryInfo`:
 
-El método `get()` devuelve un dict con esta forma:
-
-```python
-{
-    "available": bool,
-    "percentage": int,
-    "state": str,         # charging, discharging, full, unknown
-    "time": str,          # "1:23" o "1:23:45" según upower
-    "icon": str           # glifo Nerd Font (󰁹 󰂂 󰂀 󰁾 󰁼 󰂎)
-}
+```text
+available, percentage, state, time_to_full, time_to_empty, icon
 ```
 
-Los iconos se eligen según el porcentaje:
-
-| Porcentaje | Icono |
-|------------|-------|
-| ≥ 95% | 󰁹 |
-| ≥ 80% | 󰂂 |
-| ≥ 60% | 󰂀 |
-| ≥ 40% | 󰁾 |
-| ≥ 20% | 󰁼 |
-| < 20% | 󰂎 |
-
-Si no se detecta ninguna batería, devuelve `{"available": False}`. Los widgets deben comprobar esta clave antes de leer el resto.
-
-Usado por:
-
-- Popup de batería
-- Waybar (módulo `battery`)
-- Control center (tarjeta de batería)
+Si no hay batería, `available` es `false`. Iconos Nerd Font según porcentaje y carga.
 
 ---
 
 ## wifi
 
-**Archivo:** `archiso/airootfs/usr/share/churros/services/wifi.py`
+Wrapper sobre `nmcli`.
 
-Wrapper sobre `nmcli` (NetworkManager).
+`get()` → `WifiInfo`: `available`, `enabled`, `connected` (SSID o `None`), `networks` (`ssid`, `signal`, `security`, `connected`, `saved`).
 
-| Método | Comando | Devuelve |
-|--------|---------|----------|
-| `get()` | `nmcli device` + `nmcli device wifi list` | dict |
-| `enable()` | `nmcli radio wifi on` | — |
-| `disable()` | `nmcli radio wifi off` | — |
-| `toggle()` | según estado actual | — |
-
-El método `get()` devuelve:
-
-```python
-{
-    "available": bool,    # ¿hay adaptador Wi-Fi?
-    "enabled": bool,      # ¿está encendido?
-    "connected": str,     # SSID activo, "" si ninguno
-    "networks": [
-        {
-            "ssid": str,
-            "signal": int,    # 0–100
-            "connected": bool
-        },
-        ...
-    ]
-}
-```
-
-Si no hay adaptador, devuelve solo `{"available": False, ...}` y la lista `networks` queda vacía.
-
-Usado por:
-
-- Popup de red
-- Waybar (módulo `network` cuando el dispositivo es Wi-Fi)
-- Control center (tarjeta de red)
+También: `enable` / `disable` / `toggle`, `connect`, `connect_hidden`, `disconnect`, `forget`, `scan`.
 
 ---
 
 ## ethernet
 
-**Archivo:** `archiso/airootfs/usr/share/churros/services/ethernet.py`
+`get()` → `EthernetInfo`: `available`, `connected`, `interface`, `connection`.
 
-Wrapper sobre `nmcli` para interfaces cableadas.
-
-| Método | Comando | Devuelve |
-|--------|---------|----------|
-| `get()` | `nmcli device` | dict |
-
-El método `get()` devuelve:
-
-```python
-{
-    "available": bool,      # ¿hay adaptador Ethernet?
-    "connected": bool,
-    "interface": str,       # nombre del dispositivo (eth0, enp3s0, ...)
-    "connection": str       # nombre del perfil de conexión
-}
-```
-
-Acepta tanto el estado `connected` como `conectado` (NetworkManager i18n).
-
-Usado por:
-
-- Popup de red (sección Ethernet)
-- Control center (tarjeta de red)
+También: `speed(device)`, `ip(device)`, `connect`, `disconnect`.
 
 ---
 
 ## brightness
 
-**Archivo:** `archiso/airootfs/usr/share/churros/services/brightness.py`
+`available()` mira `/sys/class/backlight`. `get()` → `{ available, brightness }` (0–100). `set(value)` usa `brightnessctl`.
 
-Wrapper sobre `brightnessctl` y `/sys/class/backlight`.
+Si no hay backlight (GPU externa, escritorio), `available` es `false` y el slider se desactiva.
 
-| Método | Comando | Devuelve |
-|--------|---------|----------|
-| `available()` | (lectura de `/sys/class/backlight`) | bool |
-| `get()` | `brightnessctl g` + `brightnessctl m` | dict |
-| `set(value)` | `brightnessctl set <value>%` | — |
+---
 
-El método `get()` devuelve:
+## bluetooth
 
-```python
-{
-    "available": bool,
-    "brightness": int   # 0–100
-}
-```
+Wrapper real sobre `bluetoothctl` (ya no es una lista hardcodeada).
 
-Si no hay soporte de brillo por software (por ejemplo, algunas GPUs externas), `available()` devuelve `False` y `set()` se vuelve no-op. El widget de brillo desactiva su slider en ese caso y muestra un mensaje informativo.
-
-Usado por:
-
-- Popup de brillo
-- Waybar (módulo `custom/brightness`)
+| Función | Acción |
+|---------|--------|
+| `available()` / `is_enabled()` / `is_blocked()` | Estado del adaptador |
+| `enable()` / `disable()` | Power |
+| `scan_start()` / `scan_stop()` | Escaneo |
+| `list_devices()` | `BtDevice { address, name, connected }` |
+| `connect` / `disconnect` / `pair` / `remove` | Por dirección |
 
 ---
 
 ## power
 
-**Archivo:** `archiso/airootfs/usr/share/churros/services/power.py`
+| Función | Comando |
+|---------|---------|
+| `lock()` | `loginctl lock-session` |
+| `logout()` | `niri msg action quit` (si el desktop es Hyprland, `hyprctl dispatch exit`) |
+| `suspend()` | `systemctl suspend` |
+| `hibernate()` | `systemctl hibernate` (`can_hibernate()` primero) |
+| `restart()` | `systemctl reboot` |
+| `shutdown()` | `systemctl poweroff` |
 
-Wrapper sobre `loginctl`, `niri msg` y `systemctl`.
+---
 
-| Método | Comando | Acción |
-|--------|---------|--------|
-| `lock()` | `loginctl lock-session` | bloquea la sesión |
-| `logout()` | `niri msg action quit` | sale de Niri |
-| `suspend()` | `systemctl suspend` | suspende |
-| `hibernate()` | `systemctl hibernate` | hiberna |
-| `restart()` | `systemctl reboot` | reinicia |
-| `shutdown()` | `systemctl poweroff` | apaga |
+# Preferencias
 
-No hay método `get()`: las acciones de energía son one-shot y no devuelven estado. Cada acción del popup invoca directamente el método correspondiente.
-
-Usado por:
-
-- Popup de power
-- Waybar (módulo `custom/power`)
+Los servicios de `churros-settings` (tema, acento, niri, mako, wallpaper, …) no están en este crate: viven en `rust/preferences/src/services/`. Ver `docs/preferences.md`.
 
 ---
 
 # Best Practices
 
-- No guardar estado en los servicios: cada llamada es independiente y refleja la realidad del sistema.
-- Devolver siempre dicts desde `get()` para que los widgets puedan usar `data["key"]` sin manejar tuplas o clases.
-- Comprobar `available` antes de leer otros campos: muchos servicios exponen esta clave para entornos donde el hardware no está presente (por ejemplo, batería en un escritorio).
-- Usar `subprocess.check_output` con `text=True` para evitar decode manual; envolver en `try/except` cuando la llamada pueda fallar (red, hardware ausente).
-- Mantener el servicio delgado: la lógica de presentación (formatear iconos, calcular porcentajes) pertenece al widget, no al servicio.
+- No guardar estado: cada llamada lee el sistema.
+- Comprobar `available` antes de pintar widgets.
+- Timeouts cortos (`run`) para no bloquear el hilo de UI; el control center ya refresca en un hilo aparte.
+- Presentación (iconos, porcentajes) en el widget, no en el servicio, salvo iconos que el servicio ya calcula (batería).
 
 ---
 
 # Future Work
 
-- Servicio de Bluetooth: hoy el popup de Bluetooth usa una lista hardcodeada. Hace falta un wrapper sobre `bluetoothctl` o `bluez` DBus para enumerar dispositivos emparejados.
-- Servicio de audio por dispositivo: hoy `wpctl @DEFAULT_AUDIO_SINK@` siempre opera sobre el sink activo. Para un control center avanzado habría que listar sinks y permitir elegir.
-- Notificaciones: integrar `dunst` o `mako` como servicio y exponer API para que las apps manden notificaciones.
-- Tema dinámico: un servicio que observe el estado del sistema (batería baja, red perdida) y dispare notificaciones automáticamente.
+- Audio: elegir sink desde el control center con la lista que ya expone `list_sinks`.
+- Notificaciones: API sobre mako para que las apps manden avisos.
+- Tema dinámico ante batería baja o red perdida.


### PR DESCRIPTION
Reescribe apps, preferencias, popups y servicios para el workspace rust/ (binarios desplegados, churros_services, toggle nativo de churros-popup). Quita el runtime Python.