### PR TITLE
fix: ampliar overlay live para que Bazaar sincronice Flathub

### DIFF
--- a/archiso/efiboot/loader/entries/01-archiso-linux.conf
+++ b/archiso/efiboot/loader/entries/01-archiso-linux.conf
@@ -2,4 +2,4 @@ title    ChurrOS Live (x86_64, UEFI)
 sort-key 01
 linux    /%INSTALL_DIR%/boot/%ARCH%/vmlinuz-linux
 initrd   /%INSTALL_DIR%/boot/%ARCH%/initramfs-linux.img
-options  archisobasedir=%INSTALL_DIR% archisosearchuuid=%ARCHISO_UUID% copytoram=n
+options  archisobasedir=%INSTALL_DIR% archisosearchuuid=%ARCHISO_UUID% copytoram=n cow_spacesize=2G

--- a/archiso/efiboot/loader/entries/02-archiso-speech-linux.conf
+++ b/archiso/efiboot/loader/entries/02-archiso-speech-linux.conf
@@ -2,4 +2,4 @@ title    ChurrOS Live (Speech)
 sort-key 02
 linux    /%INSTALL_DIR%/boot/%ARCH%/vmlinuz-linux
 initrd   /%INSTALL_DIR%/boot/%ARCH%/initramfs-linux.img
-options  archisobasedir=%INSTALL_DIR% archisosearchuuid=%ARCHISO_UUID% accessibility=on copytoram=n
+options  archisobasedir=%INSTALL_DIR% archisosearchuuid=%ARCHISO_UUID% accessibility=on copytoram=n cow_spacesize=2G

--- a/archiso/grub/grub.cfg
+++ b/archiso/grub/grub.cfg
@@ -42,17 +42,20 @@ timeout=15
 timeout_style=menu
 
 
+# cow_spacesize=2G: the default 256M overlay cannot satisfy Flatpak's
+# 500MB OSTree reserve, so Bazaar fails to sync Flathub AppStream.
+
 # Menu entries
 
 menuentry "ChurrOS Live(%ARCH%, ${archiso_platform})" --class arch --class gnu-linux --class gnu --class os --id 'archlinux' {
     set gfxpayload=keep
-    linux /%INSTALL_DIR%/boot/%ARCH%/vmlinuz-linux archisobasedir=%INSTALL_DIR% archisosearchuuid=%ARCHISO_UUID% copytoram=n
+    linux /%INSTALL_DIR%/boot/%ARCH%/vmlinuz-linux archisobasedir=%INSTALL_DIR% archisosearchuuid=%ARCHISO_UUID% copytoram=n cow_spacesize=2G
     initrd /%INSTALL_DIR%/boot/%ARCH%/initramfs-linux.img
 }
 
 menuentry "ChurrOS Live Accessibility (%ARCH%, ${archiso_platform})" --hotkey s --class arch --class gnu-linux --class gnu --class os --id 'archlinux-accessibility' {
     set gfxpayload=keep
-    linux /%INSTALL_DIR%/boot/%ARCH%/vmlinuz-linux archisobasedir=%INSTALL_DIR% archisosearchuuid=%ARCHISO_UUID% accessibility=on copytoram=n
+    linux /%INSTALL_DIR%/boot/%ARCH%/vmlinuz-linux archisobasedir=%INSTALL_DIR% archisosearchuuid=%ARCHISO_UUID% accessibility=on copytoram=n cow_spacesize=2G
     initrd /%INSTALL_DIR%/boot/%ARCH%/initramfs-linux.img
 }
 

--- a/archiso/grub/loopback.cfg
+++ b/archiso/grub/loopback.cfg
@@ -23,13 +23,13 @@ timeout_style=menu
 
 menuentry "ChurrOS live (%ARCH%, ${archiso_platform})" --class arch --class gnu-linux --class gnu --class os --id 'archlinux' {
     set gfxpayload=keep
-    linux /%INSTALL_DIR%/boot/%ARCH%/vmlinuz-linux archisobasedir=%INSTALL_DIR% img_dev=UUID=${archiso_img_dev_uuid} img_loop="${iso_path}" copytoram=n
+    linux /%INSTALL_DIR%/boot/%ARCH%/vmlinuz-linux archisobasedir=%INSTALL_DIR% img_dev=UUID=${archiso_img_dev_uuid} img_loop="${iso_path}" copytoram=n cow_spacesize=2G
     initrd /%INSTALL_DIR%/boot/%ARCH%/initramfs-linux.img
 }
 
 menuentry "ChurrOS Live Accesibility (%ARCH%, ${archiso_platform})" --hotkey s --class arch --class gnu-linux --class gnu --class os --id 'archlinux-accessibility' {
     set gfxpayload=keep
-    linux /%INSTALL_DIR%/boot/%ARCH%/vmlinuz-linux archisobasedir=%INSTALL_DIR% img_dev=UUID=${archiso_img_dev_uuid} img_loop="${iso_path}" accessibility=on copytoram=n
+    linux /%INSTALL_DIR%/boot/%ARCH%/vmlinuz-linux archisobasedir=%INSTALL_DIR% img_dev=UUID=${archiso_img_dev_uuid} img_loop="${iso_path}" accessibility=on copytoram=n cow_spacesize=2G
     initrd /%INSTALL_DIR%/boot/%ARCH%/initramfs-linux.img
 }
 

--- a/archiso/syslinux/archiso_pxe-linux.cfg
+++ b/archiso/syslinux/archiso_pxe-linux.cfg
@@ -6,7 +6,7 @@ ENDTEXT
 MENU LABEL ChurrOS Live (%ARCH%, NBD)
 LINUX ::/%INSTALL_DIR%/boot/%ARCH%/vmlinuz-linux
 INITRD ::/%INSTALL_DIR%/boot/%ARCH%/initramfs-linux.img
-APPEND archisobasedir=%INSTALL_DIR% archisosearchuuid=%ARCHISO_UUID% archiso_nbd_srv=${pxeserver} cms_verify=y
+APPEND archisobasedir=%INSTALL_DIR% archisosearchuuid=%ARCHISO_UUID% archiso_nbd_srv=${pxeserver} cms_verify=y cow_spacesize=2G
 SYSAPPEND 3
 
 LABEL arch_nfs
@@ -17,7 +17,7 @@ ENDTEXT
 MENU LABEL Arch Linux install medium (%ARCH%, NFS)
 LINUX ::/%INSTALL_DIR%/boot/%ARCH%/vmlinuz-linux
 INITRD ::/%INSTALL_DIR%/boot/%ARCH%/initramfs-linux.img
-APPEND archisobasedir=%INSTALL_DIR% archiso_nfs_srv=${pxeserver}:/run/archiso/bootmnt cms_verify=y
+APPEND archisobasedir=%INSTALL_DIR% archiso_nfs_srv=${pxeserver}:/run/archiso/bootmnt cms_verify=y cow_spacesize=2G
 SYSAPPEND 3
 
 LABEL arch_http
@@ -28,5 +28,5 @@ ENDTEXT
 MENU LABEL Arch Linux install medium (%ARCH%, HTTP)
 LINUX ::/%INSTALL_DIR%/boot/%ARCH%/vmlinuz-linux
 INITRD ::/%INSTALL_DIR%/boot/%ARCH%/initramfs-linux.img
-APPEND archisobasedir=%INSTALL_DIR% archiso_http_srv=http://${pxeserver}/ cms_verify=y
+APPEND archisobasedir=%INSTALL_DIR% archiso_http_srv=http://${pxeserver}/ cms_verify=y cow_spacesize=2G
 SYSAPPEND 3

--- a/archiso/syslinux/archiso_sys-linux.cfg
+++ b/archiso/syslinux/archiso_sys-linux.cfg
@@ -6,7 +6,7 @@ ENDTEXT
 MENU LABEL ChurrOS Live (%ARCH%, BIOS)
 LINUX /%INSTALL_DIR%/boot/%ARCH%/vmlinuz-linux
 INITRD /%INSTALL_DIR%/boot/%ARCH%/initramfs-linux.img
-APPEND archisobasedir=%INSTALL_DIR% archisosearchuuid=%ARCHISO_UUID% copytoram=n
+APPEND archisobasedir=%INSTALL_DIR% archisosearchuuid=%ARCHISO_UUID% copytoram=n cow_spacesize=2G
 
 # Accessibility boot option
 LABEL archspeech
@@ -17,4 +17,4 @@ ENDTEXT
 MENU LABEL Arch Linux install medium (%ARCH%, BIOS) with ^speech
 LINUX /%INSTALL_DIR%/boot/%ARCH%/vmlinuz-linux
 INITRD /%INSTALL_DIR%/boot/%ARCH%/initramfs-linux.img
-APPEND archisobasedir=%INSTALL_DIR% archisosearchuuid=%ARCHISO_UUID% accessibility=on copytoram=n
+APPEND archisobasedir=%INSTALL_DIR% archisosearchuuid=%ARCHISO_UUID% accessibility=on copytoram=n cow_spacesize=2G

--- a/scripts/cli/check.sh
+++ b/scripts/cli/check.sh
@@ -375,6 +375,33 @@ else
     [ "$aur_ok" -eq 1 ] && pass "${#LOCAL_AUR[@]} local AUR packages listed in netinstall"
 fi
 
+# ------------------------------------------------------- Live overlay size
+
+section "Live overlay size"
+
+BOOT_CMDLINE_FILES=(
+    archiso/grub/grub.cfg
+    archiso/grub/loopback.cfg
+    archiso/syslinux/archiso_sys-linux.cfg
+    archiso/syslinux/archiso_pxe-linux.cfg
+    archiso/efiboot/loader/entries/01-archiso-linux.conf
+    archiso/efiboot/loader/entries/02-archiso-speech-linux.conf
+)
+
+cow_ok=1
+for boot_file in "${BOOT_CMDLINE_FILES[@]}"; do
+    if [ ! -f "$boot_file" ]; then
+        fail "$boot_file missing"
+        cow_ok=0
+        continue
+    fi
+    if ! grep -qE '(^|[[:space:]])cow_spacesize=' "$boot_file"; then
+        fail "$boot_file missing cow_spacesize= (Flatpak/Bazaar needs >500M overlay)"
+        cow_ok=0
+    fi
+done
+[ "$cow_ok" -eq 1 ] && pass "live boot entries set cow_spacesize"
+
 # ------------------------------------------------------------ Translations
 
 section "Translations"


### PR DESCRIPTION
El overlay live por defecto (256M) no cubre la reserva de 500MB de OSTree. El worker de Bazaar falla al sincronizar AppStream de Flathub y la tienda queda vacía.

Se fija `cow_spacesize=2G` en las entradas de arranque (GRUB, syslinux y EFI). `./churros check` comprueba que el parámetro sigue presente.

## Cómo probar
- Live con la ISO nueva: `df -h` debe mostrar ~2G en `cowspace` y `/`.
- Abrir Bazaar con red; el catálogo de Flathub debe poblarse.
- En una ISO anterior, `sudo mount -o remount,size=2G /run/archiso/cowspace` reproduce el mismo efecto hasta reiniciar.