### PR TITLE
fix(preferences): bugs varios + blur centralizado + tema en vivo + pywal parcial

### DIFF
--- a/archiso/airootfs/etc/skel/.config/niri/config.kdl
+++ b/archiso/airootfs/etc/skel/.config/niri/config.kdl
@@ -15,10 +15,10 @@ prefer-no-csd
 
 // Blur
 blur {
-    passes 2
-    offset 2
+    passes 3
+    offset 3
     noise 0
-    saturation 1.2
+    saturation 1.3
 }
 
 // Input
@@ -84,21 +84,45 @@ window-rule {
     open-floating true
 }
 
-// Apps de ChurrOS: glassmorphism (el blur real lo hace el compositor,
-// necesita background-effect blur true por app)
+// Apps de ChurrOS: glassmorphism — la transparencia sale del alpha del
+// fondo en CSS (GTK no soporta backdrop-filter); el blur real lo hace
+// el compositor con background-effect blur true.
+//
+// El bloque entre [CHURROS-GLASS-START] y [CHURROS-GLASS-END] lo
+// gestiona churros-settings (Modo rendimiento): la app cambia
+// blur true <-> blur false dentro de estos marcadores para
+// activar/desactivar el blur sin tocar el resto del config.
+// [CHURROS-GLASS-START]
+// Regla genérica: blur para TODAS las apps de ChurrOS
+// (org.churros.*). El match es regex: cubre popups, control-center,
+// preferences, welcome y futuras apps sin reglas extra.
 window-rule {
-    match app-id="org.churros.preferences"
+    match app-id="org.churros"
     background-effect {
         blur true
     }
 }
 
+// clip-to-geometry + geometry-corner-radius hacen que el blur siga
+// las esquinas redondeadas del CSS de cada app.
 window-rule {
-    match app-id="org.churros.Welcome"
-    background-effect {
-        blur true
-    }
+    match app-id="org.churros.popup"
+    geometry-corner-radius 20
+    clip-to-geometry true
 }
+
+window-rule {
+    match app-id="org.churros.controlcenter"
+    geometry-corner-radius 22
+    clip-to-geometry true
+}
+
+window-rule {
+    match app-id="org.churros.preferences"
+    geometry-corner-radius 16
+    clip-to-geometry true
+}
+// [CHURROS-GLASS-END]
 
 // Layer rules
 layer-rule {

--- a/archiso/airootfs/etc/systemd/system/multi-user.target.wants/sshd.service
+++ b/archiso/airootfs/etc/systemd/system/multi-user.target.wants/sshd.service
@@ -1,1 +1,0 @@
-/usr/lib/systemd/system/sshd.service

--- a/archiso/airootfs/usr/share/churros/defaults/niri/config.kdl
+++ b/archiso/airootfs/usr/share/churros/defaults/niri/config.kdl
@@ -15,10 +15,10 @@ prefer-no-csd
 
 // Blur
 blur {
-    passes 2
-    offset 2
+    passes 3
+    offset 3
     noise 0
-    saturation 1.2
+    saturation 1.3
 }
 
 // Input
@@ -83,6 +83,46 @@ window-rule {
     match title="^Picture-in-Picture$"
     open-floating true
 }
+
+// Apps de ChurrOS: glassmorphism — la transparencia sale del alpha del
+// fondo en CSS (GTK no soporta backdrop-filter); el blur real lo hace
+// el compositor con background-effect blur true.
+//
+// El bloque entre [CHURROS-GLASS-START] y [CHURROS-GLASS-END] lo
+// gestiona churros-settings (Modo rendimiento): la app cambia
+// blur true <-> blur false dentro de estos marcadores para
+// activar/desactivar el blur sin tocar el resto del config.
+// [CHURROS-GLASS-START]
+// Regla genérica: blur para TODAS las apps de ChurrOS
+// (org.churros.*). El match es regex: cubre popups, control-center,
+// preferences, welcome y futuras apps sin reglas extra.
+window-rule {
+    match app-id="org.churros"
+    background-effect {
+        blur true
+    }
+}
+
+// clip-to-geometry + geometry-corner-radius hacen que el blur siga
+// las esquinas redondeadas del CSS de cada app.
+window-rule {
+    match app-id="org.churros.popup"
+    geometry-corner-radius 20
+    clip-to-geometry true
+}
+
+window-rule {
+    match app-id="org.churros.controlcenter"
+    geometry-corner-radius 22
+    clip-to-geometry true
+}
+
+window-rule {
+    match app-id="org.churros.preferences"
+    geometry-corner-radius 16
+    clip-to-geometry true
+}
+// [CHURROS-GLASS-END]
 
 // Layer rules
 layer-rule {

--- a/archiso/airootfs/usr/share/churros/styles/churros.css
+++ b/archiso/airootfs/usr/share/churros/styles/churros.css
@@ -10,10 +10,10 @@
 
 /* ── Tokens → dark default ──────────────────────────── */
 window {
-    --bg-window:           rgba(15,15,16,.82);
-    --bg-sidebar:          rgba(18,18,20,.92);
-    --bg-group:            rgba(22,22,24,.88);
-    --bg-group-hover:      rgba(30,30,34,.92);
+    --bg-window:           rgba(15,15,16,.62);
+    --bg-sidebar:          rgba(18,18,20,.70);
+    --bg-group:            rgba(22,22,24,.75);
+    --bg-group-hover:      rgba(30,30,34,.80);
     --row-bg:              transparent;
     --row-bg-hover:        rgba(255,255,255,.04);
     --row-bg-active:       rgba(255,255,255,.08);
@@ -37,9 +37,9 @@ window {
 
 /* Light override */
 window.light {
-    --bg-window:           rgba(242,242,245,.75);
+    --bg-window:           rgba(242,242,245,.60);
     --bg-surface:          rgba(255,255,255,.58);
-    --bg-group:           rgba(255,255,255,.72);
+    --bg-group:           rgba(255,255,255,.62);
     --bg-group-hover:      rgba(0,0,0,.04);
     --row-bg:              transparent;
     --row-bg-hover:         rgba(0,0,0,.04);
@@ -62,29 +62,32 @@ window.light {
 }
 
 /* ── Window ─────────────────────────────────────────── */
+/*
+    Glassmorphism: la transparencia sale del alpha del fondo; el blur
+    NO se puede hacer con CSS de GTK (backdrop-filter no existe) — lo
+    aplica niri con window-rule { background-effect { blur true } }
+    para cada app-id de ChurrOS.
+*/
 window {
     background: var(--bg-window);
-    backdrop-filter: blur(var(--glass-blur)) saturate(1.4);
     border-radius: 16px;
 }
 
 /*
-    Cuando la ventana esta maximizada o fullscreen, no aplicamos
-    backdrop-filter ni border-radius: el fondo del monitor ya es
-    visible detras, asi que mezclarlos hace la interfaz ilegible
-    y amplifica el brillo de wallpapers claros en dark mode.
+    Cuando la ventana esta maximizada o fullscreen, no hay nada que
+    blurrear detras: el fondo del monitor ya es visible detras, asi que
+    mezclarlos hace la interfaz ilegible y amplifica el brillo de
+    wallpapers claros en dark mode.
 */
 window.maximized,
 window.fullscreen {
     background: var(--bg-window);
-    backdrop-filter: none;
     border-radius: 0;
 }
 
 window.popup {
     border-radius: 14px;
     background: var(--popover-bg);
-    backdrop-filter: blur(26px) saturate(1.5);
     border: 1px solid var(--border-soft);
     box-shadow: var(--glass-shadow);
 }
@@ -92,7 +95,6 @@ window.popup {
 /* ── Popover / Menu ─────────────────────────────────── */
 popover {
     background: var(--popover-bg);
-    backdrop-filter: blur(26px) saturate(1.5);
     border-radius: 14px;
     border: 1px solid var(--border-strong);
     box-shadow: var(--glass-shadow);
@@ -216,10 +218,6 @@ switch:checked {
     box-shadow: var(--accent-glow);
 }
 
-switch:checked slider {
-    margin-left: 24px;
-}
-
 /* ── Slider / Scale ─────────────────────────────────── */
 scale trough {
     min-height: 6px;
@@ -305,7 +303,6 @@ searchentry:focus,
 .popup,
 .about-card {
     background: var(--bg-group);
-    backdrop-filter: blur(20px) saturate(1.3);
     border-radius: 18px;
     border: 1px solid var(--border-soft);
     box-shadow: var(--glass-shadow), var(--glass-inset);
@@ -314,7 +311,6 @@ searchentry:focus,
 /* ── Sidebar ────────────────────────────────────────── */
 .sidebar {
     background: var(--bg-surface);
-    backdrop-filter: blur(var(--glass-blur)) saturate(1.3);
     border-radius: 20px;
     padding: 12px;
     margin: 16px 10px 16px 16px;

--- a/archiso/packages.x86_64
+++ b/archiso/packages.x86_64
@@ -218,6 +218,9 @@ evince
 # Calculadora
 gnome-calculator
 
+# Colores dinámicos (pywal) — desde el repo local [churros]; dependencia: imagemagick
+python-pywal
+
 # Calamares installer dependencies
 kcoreaddons
 kpmcore

--- a/installer/calamares/modules/netinstall.yaml
+++ b/installer/calamares/modules/netinstall.yaml
@@ -9,9 +9,6 @@ groups:
       - name: waypaper
         description: Selector gráfico de wallpapers con previsualización
         selected: false
-      - name: python-pywal
-        description: Genera esquemas de color desde el wallpaper
-        selected: false
       - name: wlogout
         description: Menú de salida para Wayland (Mod+Shift+Q)
         selected: false

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -38,6 +38,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "cc"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "509591b7bcd67f4ef775afad7662703b4935daaa6ec0e5605cfb1090b32a2b6d"
+dependencies = [
+ "find-msvc-tools",
+ "jobserver",
+ "libc",
+ "shlex",
+]
+
+[[package]]
 name = "cfg-expr"
 version = "0.20.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -91,6 +103,7 @@ dependencies = [
  "libadwaita",
  "serde_json",
  "tar",
+ "zstd",
 ]
 
 [[package]]
@@ -138,6 +151,12 @@ dependencies = [
  "cfg-if",
  "libc",
 ]
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d45db016d36b838f563236e9193d0ee6ce38f3f68b6c94e914b4929c96bbb890"
 
 [[package]]
 name = "futures-channel"
@@ -256,6 +275,17 @@ dependencies = [
  "pango-sys",
  "pkg-config",
  "system-deps",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
 ]
 
 [[package]]
@@ -475,6 +505,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "jobserver"
+version = "0.1.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c00acbd29eabad4a2392fa0e921c874934dbbf4194312ad20f04a0ed67a3cb3"
+dependencies = [
+ "getrandom",
+ "libc",
+]
+
+[[package]]
 name = "libadwaita"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -594,6 +634,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
 name = "rustc_version"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -671,6 +717,12 @@ checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
  "serde_core",
 ]
+
+[[package]]
+name = "shlex"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "slab"
@@ -847,3 +899,31 @@ name = "zmij"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"
+
+[[package]]
+name = "zstd"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.16+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
+dependencies = [
+ "cc",
+ "pkg-config",
+]

--- a/rust/churros-welcome/assets/style.css
+++ b/rust/churros-welcome/assets/style.css
@@ -1,11 +1,13 @@
 /* ==========================================================
    ChurrOS Welcome — Liquid Glass
    Accent: #F97316  Fondo: #0f0f10
+
+   Transparencia vía alpha del fondo; el blur lo aplica niri
+   (window-rule background-effect blur true para org.churros.Welcome).
    ========================================================== */
 
 window {
-    background: rgba(15,15,16,.82);
-    backdrop-filter: blur(24px) saturate(1.4);
+    background: rgba(15,15,16,.58);
     color: #f5f5f5;
     min-width: 320px;
     min-height: 320px;
@@ -23,8 +25,9 @@ window {
     font-size: 52px;
     font-weight: 800;
     letter-spacing: -0.04em;
-    background: linear-gradient(135deg, #FB923C, #F97316, #C2410C);
-    -gtk-gradient-text: linear-gradient(135deg, #FB923C 0%, #F97316 100%);
+    /* Los colores del texto los pone el markup (span white + #ff8c00);
+       background/-gtk-gradient-text aquí pintaban una CAJA naranja opaca
+       detrás del texto y hacían el "OS" naranja invisible. */
     color: #F97316;
     text-shadow: 0 0 30px rgba(249,115,22,.30);
 }
@@ -41,7 +44,6 @@ window {
 .action-card,
 .system-card {
     background: rgba(255,255,255,.05);
-    backdrop-filter: blur(20px) saturate(1.3);
     border-radius: 24px;
     border: 1px solid rgba(249,115,22,.14);
     width: 280px;

--- a/rust/control-center/assets/style.css
+++ b/rust/control-center/assets/style.css
@@ -1,6 +1,9 @@
 /*
     ChurrOS Control Center — Liquid Glass
     Accent: #F97316  Fondo: #0f0f10
+
+    Transparencia vía alpha del fondo; el blur lo aplica niri
+    (window-rule background-effect blur true para org.churros.controlcenter).
 */
 
 window {
@@ -8,8 +11,7 @@ window {
 }
 
 .control-center {
-    background: rgba(15,15,16,.72);
-    backdrop-filter: blur(24px) saturate(1.4);
+    background: rgba(15,15,16,.55);
     border-radius: 22px;
     color: white;
     border: 1px solid rgba(255,255,255,.08);
@@ -34,7 +36,6 @@ window {
 
 .card {
     background: rgba(255,255,255,.06);
-    backdrop-filter: blur(20px) saturate(1.3);
     border-radius: 22px;
     padding: 18px;
     border: 1px solid rgba(255,255,255,.08);

--- a/rust/popups/assets/common.css
+++ b/rust/popups/assets/common.css
@@ -2,15 +2,12 @@
     ChurrOS Popups — Liquid Glass base
     Accent: #F97316
 
-    Diseño común de todos los popups: fondo glass, cabecera con icono en
-    badge, tarjetas de contenido, botones de acción y estados de foco.
-    Los CSS por popup (audio.css, network.css…) extienden o ajustan estos
-    estilos con PRIORITY_APPLICATION + 1.
+    Transparencia: el alpha del fondo de .popup; el blur lo aplica niri
+    (window-rule background-effect blur true para org.churros.popup).
 */
 
 .popup {
-    background: rgba(15,15,16,.78);
-    backdrop-filter: blur(28px) saturate(1.5);
+    background: rgba(15,15,16,.55);
     border-radius: 20px;
     border: 1px solid rgba(255,255,255,.09);
     box-shadow: 0 12px 48px rgba(0,0,0,.55),
@@ -54,7 +51,6 @@
 /* ── Tarjeta base de contenido ─────────────────────── */
 .card {
     background: rgba(255,255,255,.04);
-    backdrop-filter: blur(18px) saturate(1.2);
     border-radius: 16px;
     padding: 16px;
     border: 1px solid rgba(255,255,255,.07);

--- a/rust/popups/assets/power.css
+++ b/rust/popups/assets/power.css
@@ -11,7 +11,6 @@
     border-radius: 14px;
     padding: 13px 16px;
     background: rgba(255,255,255,.05);
-    backdrop-filter: blur(16px);
     border: 1px solid rgba(255,255,255,.07);
     transition: 200ms cubic-bezier(.4,0,.2,1);
     box-shadow: 0 1px 0 rgba(255,255,255,.05) inset;

--- a/rust/popups/src/main.rs
+++ b/rust/popups/src/main.rs
@@ -57,6 +57,16 @@ fn current_name() -> Option<String> {
     read_file(&name_file())
 }
 
+/// Nombre del popup corriendo: solo si su pid sigue vivo.
+/// Un pidfile obsoleto (SIGKILL/crash) no debe bloquear el lanzamiento.
+fn running_name() -> Option<String> {
+    if running_pid().is_some() {
+        current_name()
+    } else {
+        None
+    }
+}
+
 fn kill_process(pid: i32) {
     if !process_alive(pid) {
         return;
@@ -121,7 +131,7 @@ fn main() {
     }
 
     // Mismo popup corriendo -> apagar (toggle off)
-    if current_name().as_deref() == Some(name.as_str()) {
+    if running_name().as_deref() == Some(name.as_str()) {
         kill_popup();
         return;
     }

--- a/rust/preferences/Cargo.toml
+++ b/rust/preferences/Cargo.toml
@@ -16,3 +16,4 @@ glib = "0.22.8"
 gtk = { version = "0.11.4", package = "gtk4", features = ["v4_22"] }
 serde_json = "1"
 tar = "0.4.46"
+zstd = "0.13"

--- a/rust/preferences/assets/style.css
+++ b/rust/preferences/assets/style.css
@@ -8,10 +8,10 @@
 
 /* ── Tokens (dark default) ─────────────────────────────── */
 window {
-    --bg-window:        rgba(15,15,16,.82);
-    --bg-sidebar:       rgba(18,18,20,.92);
-    --bg-group:         rgba(22,22,24,.88);
-    --bg-group-hover:   rgba(30,30,34,.92);
+    --bg-window:        rgba(15,15,16,.62);
+    --bg-sidebar:       rgba(18,18,20,.70);
+    --bg-group:         rgba(22,22,24,.75);
+    --bg-group-hover:   rgba(30,30,34,.80);
     --row-bg:           transparent;
     --row-bg-hover:     rgba(255,255,255,.04);
     --row-bg-active:    rgba(255,255,255,.08);
@@ -34,9 +34,9 @@ window {
 
 /* Light override */
 window.light {
-    --bg-window:        rgba(242,242,245,.75);
-    --bg-sidebar:       rgba(255,255,255,.58);
-    --bg-group:         rgba(255,255,255,.72);
+    --bg-window:        rgba(242,242,245,.60);
+    --bg-sidebar:       rgba(255,255,255,.50);
+    --bg-group:         rgba(255,255,255,.62);
     --bg-group-hover:   rgba(0,0,0,.04);
     --row-bg:           transparent;
     --row-bg-hover:     rgba(0,0,0,.04);
@@ -59,21 +59,24 @@ window.light {
 }
 
 /* ── Window base (glass) ───────────────────────────────── */
+/*
+    El blur NO se puede hacer con CSS de GTK (backdrop-filter no
+    existe): lo aplica niri (window-rule background-effect blur true
+    para org.churros.preferences). Aquí solo va el alpha del fondo.
+*/
 window {
     background: var(--bg-window);
-    backdrop-filter: blur(var(--glass-blur)) saturate(1.4);
 }
 
 /*
-    Cuando la ventana esta maximizada o fullscreen, no aplicamos
-    backdrop-filter ni border-radius: el fondo del monitor ya es
-    visible detras, asi que mezclarlos hace la interfaz ilegible
-    y amplifica el brillo de wallpapers claros en dark mode.
+    Cuando la ventana esta maximizada o fullscreen, quitamos el
+    border-radius: el fondo del monitor ya es visible detras, asi que
+    mezclarlos hace la interfaz ilegible y amplifica el brillo de
+    wallpapers claros en dark mode.
 */
 window.maximized,
 window.fullscreen {
     background: var(--bg-window);
-    backdrop-filter: none;
     border-radius: 0;
 }
 
@@ -84,7 +87,6 @@ window.fullscreen {
 /* ── Sidebar (glass panel) ─────────────────────────────── */
 .sidebar {
     background: var(--bg-sidebar);
-    backdrop-filter: blur(var(--glass-blur)) saturate(1.3);
     border-radius: 18px;
     padding: 12px;
     margin: 16px 10px 16px 16px;
@@ -194,7 +196,6 @@ searchentry image {
 /* ── Group (glass card) ───────────────────────────────── */
 .group {
     background: var(--bg-group);
-    backdrop-filter: blur(16px) saturate(1.2);
     border-radius: 14px;
     padding: 4px;
     border: 1px solid var(--border-soft);
@@ -213,7 +214,6 @@ searchentry image {
 
 .group-card {
     background: var(--bg-group);
-    backdrop-filter: blur(16px) saturate(1.2);
     border: 1px solid var(--border-soft);
     border-radius: 14px;
     padding: 10px;
@@ -301,10 +301,6 @@ switch:checked {
     box-shadow: var(--accent-glow);
 }
 
-switch:checked slider {
-    margin-left: 24px;
-}
-
 /* ── Slider ──────────────────────────────────────────── */
 scale {
     min-width: 180px;
@@ -361,7 +357,6 @@ button.combo:hover {
 
 popover contents list {
     background: rgba(26,26,28,.92);
-    backdrop-filter: blur(20px);
 }
 
 popover contents listview row {
@@ -381,7 +376,6 @@ popover contents listview row:selected {
 
 popover.search-results list {
     background: var(--popover-bg, rgba(26,26,28,.96));
-    backdrop-filter: blur(20px);
 }
 
 popover.search-results row {
@@ -421,7 +415,6 @@ scrollbar slider:hover {
 /* ── About card ──────────────────────────────────────── */
 .about-card {
     background: var(--bg-group);
-    backdrop-filter: blur(20px) saturate(1.3);
     border: 1px solid var(--border-soft);
     border-radius: 18px;
     padding: 28px;

--- a/rust/preferences/src/pages/appearance.rs
+++ b/rust/preferences/src/pages/appearance.rs
@@ -7,6 +7,7 @@ use std::cell::RefCell;
 use std::rc::Rc;
 
 use crate::services::niri_config::NiriConfig;
+use crate::services::pywal::PywalService;
 use crate::services::settings;
 use crate::services::theme::ThemeService;
 use crate::services::wallpaper::WallpaperService;
@@ -56,16 +57,19 @@ pub fn build(navigator: gtk::Stack) -> Page {
         Some("Generar paleta desde el wallpaper (pywal)"),
         dynamic_active,
         Some(Box::new(move |active| {
-            settings::set("theme.dynamic_colors", serde_json::json!(active));
+            let ok = PywalService::toggle(active);
             set_feedback(
                 &feedback_rc,
                 if active {
-                    "Colores dinámicos activados"
+                    if ok {
+                        "Colores dinámicos activados"
+                    } else {
+                        "No se pudo activar (¿pywal instalado y wallpaper válido?)"
+                    }
                 } else {
                     "Colores dinámicos desactivados"
                 },
             );
-            // TODO: integración pywal (services/pywal_service.py)
         })),
     ));
 

--- a/rust/preferences/src/pages/connectivity.rs
+++ b/rust/preferences/src/pages/connectivity.rs
@@ -78,33 +78,53 @@ pub fn build(navigator: gtk::Stack) -> Page {
     page.add(wifi_group.borrow().widget());
     page.add(bluetooth_group.borrow().widget());
 
-    // Cargar datos en thread (nmcli/bluetoothctl pueden tardar).
-    // Los Rc<RefCell<Group>> NO son Send: el thread solo produce datos y
-    // los envía por canal; el hilo principal los consume en un timeout.
-    let (tx, rx) = std::sync::mpsc::channel::<ConnectivityData>();
-    std::thread::spawn(move || {
-        let _ = tx.send(load_data());
-    });
+    // reload: función reutilizable que lanza la carga en thread y repuebla.
+    // Se guarda en un Rc para poder pasarla a los callbacks de los switches
+    // y a la fila "Recargar redes".
+    let reload: Rc<RefCell<Option<Rc<dyn Fn()>>>> = Rc::new(RefCell::new(None));
 
-    let wifi_group_ui = Rc::clone(&wifi_group);
-    let bluetooth_group_ui = Rc::clone(&bluetooth_group);
-    glib::timeout_add_local(std::time::Duration::from_millis(100), move || {
-        match rx.try_recv() {
-            Ok(data) => {
-                populate(&wifi_group_ui, &bluetooth_group_ui, data);
-                glib::ControlFlow::Break
-            }
-            Err(_) => glib::ControlFlow::Continue,
+    let start_load = {
+        let wg = Rc::clone(&wifi_group);
+        let bg = Rc::clone(&bluetooth_group);
+        let reload = Rc::clone(&reload);
+        move || {
+            let (tx, rx) = std::sync::mpsc::channel::<ConnectivityData>();
+            std::thread::spawn(move || {
+                let _ = tx.send(load_data());
+            });
+            let wg = Rc::clone(&wg);
+            let bg = Rc::clone(&bg);
+            let reload = Rc::clone(&reload);
+            glib::timeout_add_local(std::time::Duration::from_millis(100), move || {
+                match rx.try_recv() {
+                    Ok(data) => {
+                        populate(&wg, &bg, data, &reload);
+                        glib::ControlFlow::Break
+                    }
+                    Err(_) => glib::ControlFlow::Continue,
+                }
+            });
         }
-    });
+    };
+
+    *reload.borrow_mut() = Some(Rc::new(start_load.clone()));
+    start_load();
 
     page
+}
+
+/// Lanza un reload (recarga de datos) si ya está inicializado.
+fn trigger_reload(reload: &Rc<RefCell<Option<Rc<dyn Fn()>>>>) {
+    if let Some(f) = reload.borrow().as_ref() {
+        f();
+    }
 }
 
 fn populate(
     wifi_group: &Rc<RefCell<Group>>,
     bluetooth_group: &Rc<RefCell<Group>>,
     data: ConnectivityData,
+    reload: &Rc<RefCell<Option<Rc<dyn Fn()>>>>,
 ) {
     // ============ Wi-Fi ============
     wifi_group.borrow_mut().clear();
@@ -119,7 +139,7 @@ fn populate(
             None,
         ));
     } else {
-        let wifi_group_ui = Rc::clone(wifi_group);
+        let wifi_reload = Rc::clone(reload);
         wifi_group.borrow_mut().add(&SwitchRow::new(
             "Activar Wi-Fi",
             None,
@@ -127,7 +147,7 @@ fn populate(
             data.wifi.enabled,
             Some(Box::new(move |active| {
                 ConnectivityService::set_wifi(active);
-                let _ = &wifi_group_ui;
+                trigger_reload(&wifi_reload);
             })),
         ));
 
@@ -191,13 +211,17 @@ fn populate(
             }
         }
 
+        let rescan_reload = Rc::clone(reload);
         wifi_group.borrow_mut().add(&Row::new(
             "Recargar redes",
             Some("Forzar un nuevo escaneo"),
             None,
             None,
             None,
-            None,
+            Some(Box::new(move |_btn| {
+                ConnectivityService::rescan_wifi();
+                trigger_reload(&rescan_reload);
+            })),
         ));
     }
 
@@ -214,7 +238,7 @@ fn populate(
             None,
         ));
     } else {
-        let bluetooth_group_ui = Rc::clone(bluetooth_group);
+        let bluetooth_reload = Rc::clone(reload);
         bluetooth_group.borrow_mut().add(&SwitchRow::new(
             "Activar Bluetooth",
             None,
@@ -222,7 +246,7 @@ fn populate(
             data.bluetooth.enabled,
             Some(Box::new(move |active| {
                 ConnectivityService::set_bluetooth(active);
-                let _ = &bluetooth_group_ui;
+                trigger_reload(&bluetooth_reload);
             })),
         ));
 

--- a/rust/preferences/src/pages/datetime.rs
+++ b/rust/preferences/src/pages/datetime.rs
@@ -310,12 +310,8 @@ fn refresh_info(ui: &TzUi) {
     if !tz.is_empty() {
         ui.tz_row.set_subtitle(&tz);
     }
-    let zone_short = DatetimeService::current_zone_short();
-    if !zone_short.is_empty() {
-        ui.status_row.set_subtitle(&zone_short);
-    } else if !tz.is_empty() {
-        ui.status_row.set_subtitle(&tz);
-    }
+    // NOTA: no tocar status_row aquí — los callbacks lo usan como feedback
+    // ("Zona horaria cambiada a ...") y antes se sobrescribía al instante.
     ui.ntp_switch.set_active(DatetimeService::get_ntp());
     let rtc = DatetimeService::get_rtc_time();
     if !rtc.is_empty() {

--- a/rust/preferences/src/pages/input.rs
+++ b/rust/preferences/src/pages/input.rs
@@ -26,9 +26,9 @@ fn run_gsettings(args: &[&str]) -> String {
     output.trim_matches(|c| c == '\'' || c == '"').to_string()
 }
 
-fn set_gsettings(key: &str, value: &str) {
+fn set_gsettings(schema: &str, key: &str, value: &str) {
     let _ = Command::new("gsettings")
-        .args(["set", "org.gnome.desktop.input-sources", key, value])
+        .args(["set", schema, key, value])
         .output();
 }
 
@@ -65,7 +65,11 @@ pub fn build(navigator: gtk::Stack) -> Page {
         None,
         None,
         Some(Box::new(|layout| {
-            set_gsettings("sources", &format!("[('xkb', '{layout}')]"));
+            set_gsettings(
+                "org.gnome.desktop.input-sources",
+                "sources",
+                &format!("[('xkb', '{layout}')]"),
+            );
             NiriConfig::set_keyboard_layout(&layout);
         })),
     );
@@ -78,7 +82,7 @@ pub fn build(navigator: gtk::Stack) -> Page {
 
     let tap_value = run_gsettings(&[
         "get",
-        "org.gnome.desktop.peripherals.mouse",
+        "org.gnome.desktop.peripherals.touchpad",
         "tap-to-click",
     ]);
     let tap_active = tap_value.to_lowercase().contains("true");
@@ -89,7 +93,11 @@ pub fn build(navigator: gtk::Stack) -> Page {
         Some("Raton: clic con un toque"),
         tap_active,
         Some(Box::new(|active| {
-            set_gsettings("tap-to-click", if active { "true" } else { "false" });
+            set_gsettings(
+                "org.gnome.desktop.peripherals.touchpad",
+                "tap-to-click",
+                if active { "true" } else { "false" },
+            );
         })),
     ));
 

--- a/rust/preferences/src/pages/keyboard.rs
+++ b/rust/preferences/src/pages/keyboard.rs
@@ -5,10 +5,9 @@
 
 use gtk::prelude::*;
 
-use std::cell::RefCell;
-use std::rc::Rc;
+use std::rc::{Rc, Weak};
 
-use crate::services::keyboard::{Bind, KeyboardService};
+use crate::services::keyboard::{is_valid_key, Bind, KeyboardService};
 use crate::widgets::group::Group;
 use crate::widgets::page::Page;
 use crate::widgets::row::Row;
@@ -19,17 +18,33 @@ const ACTION_TYPES: [(&str, &str); 3] = [
     ("builtin", "Accion de Niri"),
 ];
 
+const BUILTIN_ACTIONS: [&str; 19] = [
+    "close-window",
+    "quit",
+    "maximize-column",
+    "fullscreen-window",
+    "switch-preset-column-width",
+    "toggle-window-floating",
+    "focus-column-left",
+    "focus-column-right",
+    "focus-window-up",
+    "focus-window-down",
+    "move-column-left",
+    "move-column-right",
+    "move-window-up",
+    "move-window-down",
+    "show-hotkey-overlay",
+    "toggle-overview",
+    "screenshot",
+    "screenshot-screen",
+    "screenshot-window",
+];
+
 fn categorize(cmd: &str, bind_type: &str) -> &'static str {
     let c = cmd.to_lowercase();
     let c = c.as_str();
 
     if bind_type == "spawn" || bind_type == "spawn-sh" {
-        if ["churros", "thunar", "fuzzel", "foot", "store"]
-            .iter()
-            .any(|w| c.contains(w))
-        {
-            return "Aplicaciones";
-        }
         return "Aplicaciones";
     }
 
@@ -72,7 +87,7 @@ fn categorize(cmd: &str, bind_type: &str) -> &'static str {
         return "Overlays";
     }
 
-    if cmd.contains("battery") || cmd.contains("XFBattery") || cmd.contains("playerctl") {
+    if cmd.contains("battery") || cmd.contains("playerctl") {
         return "Multimedia";
     }
 
@@ -91,13 +106,7 @@ fn categorize(cmd: &str, bind_type: &str) -> &'static str {
 }
 
 fn bind_summary(bind: &Bind) -> String {
-    let type_label = ACTION_TYPES
-        .iter()
-        .find(|(t, _)| t == &bind.kind)
-        .map(|(_, l)| *l)
-        .unwrap_or(bind.kind.as_str());
-
-    let summary = if bind.kind == "spawn" && !bind.command.is_empty() {
+    if bind.kind == "spawn" && !bind.command.is_empty() {
         if bind.args.is_empty() {
             bind.command.clone()
         } else {
@@ -111,16 +120,19 @@ fn bind_summary(bind: &Bind) -> String {
         } else {
             format!("{} {}", bind.command, bind.args)
         }
+    } else if bind.command.is_empty() {
+        "(vacio)".to_string()
     } else {
-        if bind.command.is_empty() {
-            "(vacio)".to_string()
-        } else {
-            bind.command.clone()
-        }
-    };
+        bind.command.clone()
+    }
+}
 
-    let _ = type_label;
-    summary
+fn type_label(kind: &str) -> String {
+    ACTION_TYPES
+        .iter()
+        .find(|(t, _)| t == &kind)
+        .map(|(_, l)| (*l).to_string())
+        .unwrap_or_else(|| kind.to_string())
 }
 
 pub fn build(navigator: gtk::Stack) -> Page {
@@ -131,12 +143,282 @@ pub fn build(navigator: gtk::Stack) -> Page {
         None,
     );
 
-    build_content(&page);
+    // Las callbacks de los diálogos necesitan reconstruir la página al
+    // guardar; se les pasa un Weak del Page (que se devuelve por valor).
+    let rc = Rc::new(page);
+    let weak = Rc::downgrade(&rc);
+    build_content(&rc, &weak);
 
-    page
+    match Rc::try_unwrap(rc) {
+        Ok(page) => page,
+        Err(_) => unreachable!("el Page tiene referencias vivas al construir"),
+    }
 }
 
-fn build_content(page: &Page) {
+fn clear_page(page: &Page) {
+    while let Some(child) = page.content.first_child() {
+        page.content.remove(&child);
+    }
+}
+
+fn rebuild(weak: &Weak<Page>) {
+    if let Some(page) = weak.upgrade() {
+        clear_page(&page);
+        build_content(&page, weak);
+    }
+}
+
+fn show_alert(message: &str) {
+    let dialog = gtk::AlertDialog::builder().message(message).build();
+    dialog.show(None::<&gtk::Window>);
+}
+
+/// Ventana padre desde un widget (transient_for del diálogo).
+fn parent_window(widget: &impl IsA<gtk::Widget>) -> Option<gtk::Window> {
+    widget.root().and_downcast::<gtk::Window>()
+}
+
+fn dialog_window(parent: Option<&gtk::Window>, title: &str) -> gtk::Window {
+    let dialog = gtk::Window::builder()
+        .title(title)
+        .default_width(440)
+        .resizable(false)
+        .modal(true)
+        .decorated(true)
+        .build();
+    if let Some(p) = parent {
+        dialog.set_transient_for(Some(p));
+        // Heredar la application del padre: sin esto el app-id de la
+        // ventana en Wayland queda vacío y las window-rules de niri
+        // (blur, radios) no se le aplican.
+        if let Some(app) = p.application() {
+            dialog.set_application(Some(&app));
+        }
+    }
+    dialog
+}
+
+/// Fila label + entry (diálogos de atajos).
+fn field_row(label: &str, entry: &gtk::Entry) -> gtk::Box {
+    let box_ = gtk::Box::new(gtk::Orientation::Horizontal, 8);
+    let label_widget = gtk::Label::new(Some(label));
+    label_widget.set_xalign(0.0);
+    label_widget.set_width_chars(16);
+    box_.append(&label_widget);
+    entry.set_hexpand(true);
+    box_.append(entry);
+    box_
+}
+
+fn edit_bind_dialog(parent: Option<gtk::Window>, bind: Bind, weak: Weak<Page>) {
+    let dialog = dialog_window(parent.as_ref(), "Editar atajo");
+
+    let vbox = gtk::Box::new(gtk::Orientation::Vertical, 10);
+    vbox.set_margin_top(16);
+    vbox.set_margin_bottom(16);
+    vbox.set_margin_start(16);
+    vbox.set_margin_end(16);
+
+    let header = gtk::Label::new(None);
+    header.set_markup("<b>Cambiar atajo</b>");
+    header.set_xalign(0.0);
+    vbox.append(&header);
+
+    let current = gtk::Label::new(None);
+    current.set_markup(&format!(
+        "Atajo actual: <b>{}</b>\nAccion: {}",
+        bind.key, bind.command
+    ));
+    current.set_xalign(0.0);
+    current.set_wrap(true);
+    vbox.append(&current);
+
+    vbox.append(&gtk::Separator::new(gtk::Orientation::Horizontal));
+
+    let key_entry = gtk::Entry::new();
+    key_entry.set_placeholder_text(Some("Ej: Mod+Shift+X"));
+    key_entry.set_text(&bind.key);
+    vbox.append(&field_row("Nuevo atajo:", &key_entry));
+
+    let cmd_entry = gtk::Entry::new();
+    cmd_entry.set_text(&bind.command);
+    vbox.append(&field_row("Nuevo comando:", &cmd_entry));
+
+    let args_entry = gtk::Entry::new();
+    args_entry.set_text(&bind.args);
+    vbox.append(&field_row("Argumentos:", &args_entry));
+
+    let buttons = gtk::Box::new(gtk::Orientation::Horizontal, 8);
+    buttons.set_halign(gtk::Align::End);
+
+    let cancel_btn = gtk::Button::with_label("Cancelar");
+    let dialog_weak = dialog.downgrade();
+    cancel_btn.connect_clicked(move |_| {
+        if let Some(d) = dialog_weak.upgrade() {
+            d.close();
+        }
+    });
+    buttons.append(&cancel_btn);
+
+    let save_btn = gtk::Button::with_label("Guardar");
+    save_btn.add_css_class("suggested-action");
+
+    {
+        let key_entry = key_entry.clone();
+        let cmd_entry = cmd_entry.clone();
+        let args_entry = args_entry.clone();
+        let dialog_weak = dialog.downgrade();
+        let weak = weak.clone();
+        save_btn.connect_clicked(move |_| {
+            let new_key = key_entry.text().trim().to_string();
+            let mut new_cmd = cmd_entry.text().trim().to_string();
+            let mut new_args = args_entry.text().trim().to_string();
+
+            if new_key.is_empty() {
+                if let Some(d) = dialog_weak.upgrade() {
+                    d.close();
+                }
+                show_alert("Define la nueva combinacion de teclas");
+                return;
+            }
+            if !is_valid_key(&new_key) {
+                show_alert(
+                    "Combinacion invalida: usa Mod+X, Print, Ctrl+Print, Alt+Print o XF86...",
+                );
+                return;
+            }
+
+            let mut bind_type_new = bind.kind.clone();
+            if let Some(rest) = new_cmd.strip_prefix("spawn ") {
+                bind_type_new = "spawn".to_string();
+                new_cmd = rest.trim().to_string();
+                if new_args.is_empty() {
+                    if let Some((first, rest_args)) = new_cmd.split_once(' ') {
+                        let cmd = first.to_string();
+                        new_args = rest_args.to_string();
+                        new_cmd = cmd;
+                    }
+                }
+            }
+
+            let ok = if new_key != bind.key {
+                KeyboardService::remove_keybind(&bind.key)
+                    && KeyboardService::add_keybind(&new_key, &bind_type_new, &new_cmd, &new_args)
+            } else {
+                KeyboardService::set_keybind(&bind.key, &bind_type_new, &new_cmd, &new_args)
+            };
+
+            if let Some(d) = dialog_weak.upgrade() {
+                d.close();
+            }
+            if !ok {
+                show_alert("No se pudo guardar el atajo");
+            } else {
+                rebuild(&weak);
+            }
+        });
+    }
+    buttons.append(&save_btn);
+
+    vbox.append(&buttons);
+    dialog.set_child(Some(&vbox));
+    dialog.present();
+}
+
+fn add_bind_dialog(parent: Option<gtk::Window>, weak: Weak<Page>) {
+    let dialog = dialog_window(parent.as_ref(), "Nuevo atajo");
+
+    let vbox = gtk::Box::new(gtk::Orientation::Vertical, 10);
+    vbox.set_margin_top(16);
+    vbox.set_margin_bottom(16);
+    vbox.set_margin_start(16);
+    vbox.set_margin_end(16);
+
+    let header = gtk::Label::new(None);
+    header.set_markup("<b>Nuevo atajo de teclado</b>");
+    header.set_xalign(0.0);
+    vbox.append(&header);
+
+    vbox.append(&gtk::Separator::new(gtk::Orientation::Horizontal));
+
+    let key_entry = gtk::Entry::new();
+    key_entry.set_placeholder_text(Some("Ej: Mod+Shift+X"));
+    vbox.append(&field_row("Combinacion:", &key_entry));
+
+    let cmd_entry = gtk::Entry::new();
+    cmd_entry.set_placeholder_text(Some("Ej: churros-settings o close-window"));
+    vbox.append(&field_row("Comando o accion:", &cmd_entry));
+
+    let args_entry = gtk::Entry::new();
+    args_entry.set_placeholder_text(Some("Opcional"));
+    vbox.append(&field_row("Argumentos:", &args_entry));
+
+    let buttons = gtk::Box::new(gtk::Orientation::Horizontal, 8);
+    buttons.set_halign(gtk::Align::End);
+
+    let cancel_btn = gtk::Button::with_label("Cancelar");
+    let dialog_weak = dialog.downgrade();
+    cancel_btn.connect_clicked(move |_| {
+        if let Some(d) = dialog_weak.upgrade() {
+            d.close();
+        }
+    });
+    buttons.append(&cancel_btn);
+
+    let add_btn = gtk::Button::with_label("Agregar");
+    add_btn.add_css_class("suggested-action");
+
+    {
+        let key_entry = key_entry.clone();
+        let cmd_entry = cmd_entry.clone();
+        let args_entry = args_entry.clone();
+        let dialog_weak = dialog.downgrade();
+        let weak = weak.clone();
+        add_btn.connect_clicked(move |_| {
+            let new_key = key_entry.text().trim().to_string();
+            let new_cmd = cmd_entry.text().trim().to_string();
+            let new_args = args_entry.text().trim().to_string();
+
+            if new_key.is_empty() || new_cmd.is_empty() {
+                if let Some(d) = dialog_weak.upgrade() {
+                    d.close();
+                }
+                show_alert("Define la combinacion y el comando");
+                return;
+            }
+            if !is_valid_key(&new_key) {
+                show_alert(
+                    "Combinacion invalida: usa Mod+X, Print, Ctrl+Print, Alt+Print o XF86...",
+                );
+                return;
+            }
+
+            let action_type = if BUILTIN_ACTIONS.contains(&new_cmd.as_str()) {
+                "builtin"
+            } else {
+                "spawn"
+            };
+
+            let ok = KeyboardService::add_keybind(&new_key, action_type, &new_cmd, &new_args);
+
+            if let Some(d) = dialog_weak.upgrade() {
+                d.close();
+            }
+            if !ok {
+                show_alert("No se pudo agregar el atajo");
+            } else {
+                rebuild(&weak);
+            }
+        });
+    }
+    buttons.append(&add_btn);
+
+    vbox.append(&buttons);
+    dialog.set_child(Some(&vbox));
+    dialog.present();
+}
+
+fn build_content(page: &Page, weak: &Weak<Page>) {
     let binds = KeyboardService::get_keybinds();
 
     let mut hint = Group::new("Info");
@@ -151,15 +433,15 @@ fn build_content(page: &Page) {
     page.add(hint.widget());
 
     let mut add_group = Group::new("Agregar");
+    let add_weak = weak.clone();
     add_group.add(&Row::new(
         "Agregar nuevo atajo",
         Some("Define una nueva combinacion de teclas"),
         Some("system.svg"),
         None,
         None,
-        Some(Box::new(|_btn| {
-            // TODO: diálogo de nuevo atajo (equivalente a _add_new_bind)
-            eprintln!("[keyboard] add new bind dialog pendiente de portar");
+        Some(Box::new(move |btn| {
+            add_bind_dialog(parent_window(btn), add_weak.clone());
         })),
     ));
     page.add(add_group.widget());
@@ -194,22 +476,18 @@ fn build_content(page: &Page) {
         let mut group = Group::new(cat_name);
         for bind in &cat_binds {
             let summary = bind_summary(bind);
-            let type_label = ACTION_TYPES
-                .iter()
-                .find(|(t, _)| t == &bind.kind)
-                .map(|(_, l)| *l)
-                .unwrap_or(bind.kind.as_str())
-                .to_string();
+            let subtitle = type_label(&bind.kind);
+            let bind = bind.clone();
+            let weak = weak.clone();
 
             group.add(&Row::new(
                 &summary,
-                Some(&type_label),
+                Some(&subtitle),
                 Some("system.svg"),
                 None,
                 None,
-                Some(Box::new(move |_btn| {
-                    // TODO: diálogo de edición (equivalente a _edit_bind)
-                    eprintln!("[keyboard] edit bind dialog pendiente de portar");
+                Some(Box::new(move |btn| {
+                    edit_bind_dialog(parent_window(btn), bind.clone(), weak.clone());
                 })),
             ));
         }

--- a/rust/preferences/src/pages/lock_screen.rs
+++ b/rust/preferences/src/pages/lock_screen.rs
@@ -454,6 +454,7 @@ fn on_use_current_wallpaper(state: &LockStateRef) {
     }
 
     LockScreenService::set_all(&json!({ "wallpaper_path": current }));
+    LockScreenService::apply();
     state
         .borrow()
         .use_current_row
@@ -473,6 +474,7 @@ fn on_apply_custom_path(state: &LockStateRef) {
     }
 
     LockScreenService::set_all(&json!({ "wallpaper_path": path }));
+    LockScreenService::apply();
     state
         .borrow()
         .apply_path_row

--- a/rust/preferences/src/pages/logs.rs
+++ b/rust/preferences/src/pages/logs.rs
@@ -122,17 +122,29 @@ fn set_validate(text: &str, css_class: &str) {
     });
 }
 
-/// Equivalente a _refresh_validate (síncrono; el Python usa un thread).
+/// Equivalente a _refresh_validate (asíncrono: niri validate en un thread).
 fn refresh_validate() {
     set_validate("Validando...", "row-subtitle");
 
-    let (ok, msg) = LogsService::niri_validate();
+    let (tx, rx) = std::sync::mpsc::channel::<(bool, String)>();
+    std::thread::spawn(move || {
+        let (ok, msg) = LogsService::niri_validate();
+        let _ = tx.send((ok, msg));
+    });
 
-    if ok {
-        set_validate("Config valida.", "row-subtitle");
-    } else {
-        set_validate(&format!("Config invalida:\n{msg}"), "row-title");
-    }
+    glib::timeout_add_local(std::time::Duration::from_millis(100), move || {
+        match rx.try_recv() {
+            Ok((ok, msg)) => {
+                if ok {
+                    set_validate("Config valida.", "row-subtitle");
+                } else {
+                    set_validate(&format!("Config invalida:\n{msg}"), "row-title");
+                }
+                glib::ControlFlow::Break
+            }
+            Err(_) => glib::ControlFlow::Continue,
+        }
+    });
 }
 
 /// Equivalente a _set_log.
@@ -147,15 +159,27 @@ fn set_log(text: &str) {
     });
 }
 
-/// Equivalente a _refresh_logs (síncrono; el Python usa un thread).
+/// Equivalente a _refresh_logs (asíncrono: journalctl en un thread).
 fn refresh_logs() {
     set_log("Cargando...");
 
-    let text = LogsService::niri_logs(400);
+    let (tx, rx) = std::sync::mpsc::channel::<String>();
+    std::thread::spawn(move || {
+        let text = LogsService::niri_logs(400);
+        let _ = tx.send(text);
+    });
 
-    if text.trim().is_empty() {
-        set_log("(sin logs)");
-    } else {
-        set_log(&text);
-    }
+    glib::timeout_add_local(std::time::Duration::from_millis(100), move || {
+        match rx.try_recv() {
+            Ok(text) => {
+                if text.trim().is_empty() {
+                    set_log("(sin logs)");
+                } else {
+                    set_log(&text);
+                }
+                glib::ControlFlow::Break
+            }
+            Err(_) => glib::ControlFlow::Continue,
+        }
+    });
 }

--- a/rust/preferences/src/pages/users.rs
+++ b/rust/preferences/src/pages/users.rs
@@ -5,6 +5,9 @@
 
 use gtk::prelude::*;
 
+use std::cell::Cell;
+use std::rc::Rc;
+
 use crate::services::users::UsersService;
 use crate::widgets::group::Group;
 use crate::widgets::page::Page;
@@ -45,15 +48,33 @@ pub fn build(navigator: gtk::Stack) -> Page {
     // Seguridad
     let mut security = Group::new("Seguridad");
 
-    security.add(&SwitchRow::new(
+    // Autologin: edita /etc/greetd con privilegios; si falla (pkexec
+    // cancelado, sin permisos) se revierte el switch para no mentir.
+    let autologin_row = SwitchRow::new(
         "Inicio automático",
         Some("users.svg"),
         Some("Iniciar sesión automáticamente"),
         UsersService::auto_login(),
-        Some(Box::new(|value| {
-            UsersService::set_auto_login(value);
-        })),
-    ));
+        None,
+    );
+    let autologin_switch = autologin_row.switch.clone();
+    let revert_guard = Rc::new(Cell::new(false));
+    {
+        let revert_guard = Rc::clone(&revert_guard);
+        autologin_switch.connect_notify_local(Some("active"), move |switch, _| {
+            if revert_guard.get() {
+                return;
+            }
+            revert_guard.set(true);
+            let active = switch.is_active();
+            let ok = UsersService::set_auto_login(active);
+            if !ok {
+                switch.set_active(!active);
+            }
+            revert_guard.set(false);
+        });
+    }
+    security.add(&autologin_row);
 
     page.add(security.widget());
 

--- a/rust/preferences/src/services/accent.rs
+++ b/rust/preferences/src/services/accent.rs
@@ -105,7 +105,32 @@ impl AccentService {
     pub fn set(color: &str) {
         settings::set("accent.color", serde_json::json!(color));
         Self::write_accent_css(color);
-        // TODO: pywal integration
+        // Si pywal está activo, el color con nombre se sobrescribe por la
+        // paleta dinámica (paridad con accent.py del Python).
+        if crate::services::pywal::PywalService::enabled() {
+            if let Some(palette) = crate::services::pywal::PywalService::generate() {
+                crate::services::pywal::PywalService::apply_accent(&palette);
+            }
+        }
+    }
+
+    /// Escribe accent.css con un hex arbitrario (para pywal). NO persiste en
+    /// settings.json: el color custom se sobrescribe la próxima vez que el
+    /// usuario elige un color con nombre.
+    pub fn set_hex(hex: &str) {
+        let base = if hex.starts_with('#') {
+            hex.to_string()
+        } else {
+            format!("#{hex}")
+        };
+        let path = Self::accent_css_path();
+        if let Some(parent) = path.parent() {
+            let _ = fs::create_dir_all(parent);
+        }
+        let _ = fs::write(
+            path,
+            Self::build_accent_css(&base, "dynamic colors (pywal)"),
+        );
     }
 
     pub fn ensure() {

--- a/rust/preferences/src/services/audio.rs
+++ b/rust/preferences/src/services/audio.rs
@@ -149,43 +149,53 @@ fn devices(section: &str) -> Vec<AudioDevice> {
             inside = true;
             continue;
         }
-        if inside {
-            if line.trim().is_empty() {
-                break;
-            }
-            let t = line.trim();
-            let (is_default, rest) = match t.strip_prefix('*') {
-                Some(r) => (true, r.trim()),
-                None => (false, t),
-            };
-
-            // regex Python: (\*?)\s*([0-9]+)\.\s+(.*)
-            let digits: String = rest
-                .chars()
-                .take_while(|c| c.is_ascii_digit())
-                .collect();
-            if digits.is_empty() {
-                continue;
-            }
-            let after_digits = &rest[digits.len()..];
-            let Some(after_dot) = after_digits.strip_prefix('.') else {
-                continue;
-            };
-            // \s+ obligatorio tras el punto (paridad con la regex)
-            if !after_dot.starts_with(|c: char| c.is_whitespace()) {
-                continue;
-            }
-            let name = after_dot.trim_start();
-            if name.is_empty() {
-                continue;
-            }
-            let id = digits.parse::<u32>().unwrap_or(0);
-            result.push(AudioDevice {
-                id,
-                name: name.to_string(),
-                default: is_default,
-            });
+        if !inside {
+            continue;
         }
+        if line.trim().is_empty() {
+            break;
+        }
+
+        // wpctl antepone caracteres de árbol (│ ├ └ ─) al margen; el trim
+        // normal no los elimina y el parser fallaba con PipeWire moderno.
+        let t = line.trim_start_matches(['│', '├', '└', '─', ' ', '\t']);
+        let (is_default, rest) = match t.strip_prefix('*') {
+            Some(r) => (true, r.trim_start()),
+            None => (false, t.trim_start()),
+        };
+
+        // regex Python: (\*?)\s*([0-9]+)\.\s+(.*)
+        let digits: String = rest
+            .chars()
+            .take_while(|c| c.is_ascii_digit())
+            .collect();
+        if digits.is_empty() {
+            continue;
+        }
+        let after_digits = &rest[digits.len()..];
+        let Some(after_dot) = after_digits.strip_prefix('.') else {
+            continue;
+        };
+        // \s+ obligatorio tras el punto (paridad con la regex)
+        if !after_dot.starts_with(char::is_whitespace) {
+            continue;
+        }
+        let mut name = after_dot.trim_start();
+        // Quitar el sufijo "[vol: ...]" (mismo comportamiento que el
+        // crate churros-services de los popups).
+        if let Some(idx) = name.find(" [vol:") {
+            name = &name[..idx];
+        }
+        let name = name.trim_end();
+        if name.is_empty() {
+            continue;
+        }
+        let id = digits.parse::<u32>().unwrap_or(0);
+        result.push(AudioDevice {
+            id,
+            name: name.to_string(),
+            default: is_default,
+        });
     }
     result
 }

--- a/rust/preferences/src/services/backup_service.rs
+++ b/rust/preferences/src/services/backup_service.rs
@@ -37,6 +37,26 @@ fn dotfiles() -> Vec<(&'static str, PathBuf)> {
 
 const DEFAULTS_DIR: &str = "/usr/share/churros/defaults";
 
+/// Une `base` + `rel` rechazando rutas absolutas y componentes ".."
+/// (protección contra path traversal en backups maliciosos).
+fn safe_join(base: &Path, rel: &str) -> Option<PathBuf> {
+    let rel_path = Path::new(rel);
+    if rel_path.is_absolute() {
+        return None;
+    }
+    if rel_path.components().any(|c| {
+        matches!(
+            c,
+            std::path::Component::ParentDir
+                | std::path::Component::RootDir
+                | std::path::Component::Prefix(_)
+        )
+    }) {
+        return None;
+    }
+    Some(base.join(rel_path))
+}
+
 /// Copia recursiva de directorio (como shutil.copytree).
 fn copy_dir_all(src: &Path, dst: &Path) -> std::io::Result<()> {
     fs::create_dir_all(dst)?;
@@ -79,7 +99,9 @@ impl BackupService {
 
         let result = (|| -> std::io::Result<()> {
             let file = fs::File::create(&tmp)?;
-            let mut tar = tar::Builder::new(file);
+            // Compresión zstd real (la extensión es .tar.zst).
+            let encoder = zstd::stream::Encoder::new(file, 3)?;
+            let mut tar = tar::Builder::new(encoder);
 
             if settings_file().exists() {
                 tar.append_path_with_name(&settings_file(), "churros/settings.json")?;
@@ -91,7 +113,8 @@ impl BackupService {
                 }
             }
 
-            tar.finish()?;
+            let encoder = tar.into_inner()?;
+            encoder.finish()?;
             Ok(())
         })();
 
@@ -120,7 +143,20 @@ impl BackupService {
         let mut has_dotfiles = false;
 
         let file = fs::File::open(&src).map_err(|e| format!("Archivo invalido: {e}"))?;
-        let mut archive = tar::Archive::new(file);
+        let raw = std::io::Read::bytes(file)
+            .collect::<Result<Vec<u8>, _>>()
+            .map_err(|e| format!("Archivo invalido: {e}"))?;
+
+        // Backup comprimido con zstd (magic 28 B5 2F FD) o tar plano (legacy).
+        let reader: Box<dyn Read> = if raw.starts_with(&[0x28, 0xB5, 0x2F, 0xFD]) {
+            Box::new(
+                zstd::stream::read::Decoder::new(&raw[..])
+                    .map_err(|e| format!("Archivo invalido: {e}"))?,
+            )
+        } else {
+            Box::new(&raw[..])
+        };
+        let mut archive = tar::Archive::new(reader);
 
         let entries = archive
             .entries()
@@ -152,15 +188,16 @@ impl BackupService {
             return Err("El archivo no es un backup de ChurrOS".to_string());
         }
 
-        // NOTA: igual que el Python original, las rutas no se sanitizan
-        // (un tar malicioso con ".." podría escribir fuera de ~/.config).
+        // Sanitizar rutas: rechazar absolutas y ".." (path traversal).
         for (name, is_dir, data) in items {
             if name.starts_with("churros/") {
                 if is_dir {
                     continue;
                 }
                 let rel = name.trim_start_matches("churros/");
-                let target = churros_dir().join(rel);
+                let Some(target) = safe_join(&churros_dir(), rel) else {
+                    continue;
+                };
                 if let Some(parent) = target.parent() {
                     fs::create_dir_all(parent).map_err(|e| e.to_string())?;
                 }
@@ -170,6 +207,11 @@ impl BackupService {
                 let _ = parts.next(); // "dotfiles"
                 let Some(df_name) = parts.next() else { continue };
                 let rest = parts.next().unwrap_or("");
+
+                // Solo dotfiles conocidos (evita escribir dirs arbitrarios).
+                if !dotfiles().iter().any(|(n, _)| *n == df_name) {
+                    continue;
+                }
 
                 let target_dir = home().join(".config").join(df_name);
 
@@ -181,7 +223,9 @@ impl BackupService {
                     continue;
                 }
 
-                let target = target_dir.join(rest);
+                let Some(target) = safe_join(&target_dir, rest) else {
+                    continue;
+                };
                 if let Some(parent) = target.parent() {
                     fs::create_dir_all(parent).map_err(|e| e.to_string())?;
                 }
@@ -238,12 +282,10 @@ impl BackupService {
 
     /// Recarga waybar/mako/fuzzel (equivalente a _reload_services).
     pub fn reload_services() {
-        // pkill -fuzzel es un bug del Python original (pkill interpreta
-        // "-fuzzel" como -f + -u "zzel"); se replica tal cual por paridad.
         for cmd in [
             vec!["pkill", "-HUP", "waybar"],
             vec!["makoctl", "reload"],
-            vec!["pkill", "-fuzzel"],
+            vec!["pkill", "-x", "fuzzel"],
         ] {
             let _ = Command::new(&cmd[0])
                 .args(&cmd[1..])

--- a/rust/preferences/src/services/connectivity.rs
+++ b/rust/preferences/src/services/connectivity.rs
@@ -162,6 +162,11 @@ impl ConnectivityService {
         run_no_output(&["nmcli", "radio", "wifi", if enabled { "on" } else { "off" }]);
     }
 
+    /// Fuerza un reescaneo de redes Wi-Fi (nmcli device wifi rescan).
+    pub fn rescan_wifi() {
+        run_no_output(&["nmcli", "device", "wifi", "rescan"]);
+    }
+
     /// SSID de la red activa, si hay.
     pub fn current_network() -> Option<String> {
         if !Self::wifi_available() {
@@ -215,7 +220,7 @@ impl ConnectivityService {
             let signal = fields.next().unwrap_or_default();
             let security = fields.next().unwrap_or_default();
 
-            let ssid = ssid.replace("\\:", ":");
+            let ssid = ssid;
             let ssid_final = if ssid.is_empty() { "Hidden Network".to_string() } else { ssid };
             let signal = parse_signal(&signal);
 
@@ -224,7 +229,7 @@ impl ConnectivityService {
                 saved: saved.contains(&ssid_final),
                 ssid: ssid_final,
                 signal,
-                security: security.replace("\\:", ":"),
+                security,
             };
             networks.push(network);
         }
@@ -243,7 +248,7 @@ impl ConnectivityService {
             b.connected
                 .cmp(&a.connected)
                 .then(b.saved.cmp(&a.saved))
-                .then(a.signal.cmp(&b.signal))
+                .then(b.signal.cmp(&a.signal))
         });
         deduped
     }
@@ -251,16 +256,23 @@ impl ConnectivityService {
     /// Nombres de conexiones wifi guardadas (802-11-wireless).
     fn saved_networks() -> std::collections::HashSet<String> {
         let mut saved = std::collections::HashSet::new();
-        let (code, out, _) = wifi_run(&["nmcli", "-t", "-f", "NAME,TYPE", "connection", "show"]);
+        let (code, out, _) = wifi_run(&[
+            "nmcli",
+            "--escape",
+            "yes",
+            "-t",
+            "-f",
+            "NAME,TYPE",
+            "connection",
+            "show",
+        ]);
         if code != 0 {
             return saved;
         }
         for line in out.lines() {
-            let mut parts = line.splitn(2, ':');
-            let name = parts.next().unwrap_or("");
-            let conn_type = parts.next().unwrap_or("");
-            if conn_type == "802-11-wireless" {
-                saved.insert(name.to_string());
+            let fields = parse_escaped_fields(line);
+            if fields.len() >= 2 && fields[1] == "802-11-wireless" {
+                saved.insert(fields[0].clone());
             }
         }
         saved

--- a/rust/preferences/src/services/cursor.rs
+++ b/rust/preferences/src/services/cursor.rs
@@ -195,7 +195,7 @@ fn set_niri_cursor_size(size: f64) {
         let new_block = rewrite_cursor_block(block, size_i);
         new_content = Some(format!(
             "{}{}{}",
-            &content[line_start..brace_open],
+            &content[line_start..=brace_open],
             new_block,
             &content[close..]
         ));

--- a/rust/preferences/src/services/cursor.rs
+++ b/rust/preferences/src/services/cursor.rs
@@ -30,6 +30,31 @@ fn uid() -> u32 {
     1000
 }
 
+/// Socket wayland real del runtime dir (wayland-0, wayland-1, ...).
+fn detect_wayland_display() -> Option<String> {
+    if let Ok(v) = std::env::var("WAYLAND_DISPLAY") {
+        if !v.is_empty() {
+            return Some(v);
+        }
+    }
+    let xrd = std::env::var("XDG_RUNTIME_DIR")
+        .unwrap_or_else(|_| format!("/run/user/{}", uid()));
+    let dir = PathBuf::from(&xrd);
+    if !dir.is_dir() {
+        return None;
+    }
+    let Ok(entries) = fs::read_dir(&dir) else {
+        return None;
+    };
+    let mut socks: Vec<String> = entries
+        .flatten()
+        .filter_map(|e| e.file_name().into_string().ok())
+        .filter(|n| n.starts_with("wayland-"))
+        .collect();
+    socks.sort();
+    socks.first().cloned()
+}
+
 fn niri_config_path() -> PathBuf {
     PathBuf::from(home()).join(".config").join("niri").join("config.kdl")
 }
@@ -70,7 +95,9 @@ fn write_gtk_ini(key: &str, value: &str) {
 fn apply_live_cursor_theme(theme_name: &str, size: i64) {
     let mut env: Vec<(String, String)> = std::env::vars().collect();
     if !env.iter().any(|(k, _)| k == "WAYLAND_DISPLAY") {
-        env.push(("WAYLAND_DISPLAY".to_string(), "wayland-1".to_string()));
+        if let Some(sock) = detect_wayland_display() {
+            env.push(("WAYLAND_DISPLAY".to_string(), sock));
+        }
     }
     if !env.iter().any(|(k, _)| k == "XDG_RUNTIME_DIR") {
         env.push(("XDG_RUNTIME_DIR".to_string(), format!("/run/user/{}", uid())));

--- a/rust/preferences/src/services/display.rs
+++ b/rust/preferences/src/services/display.rs
@@ -296,10 +296,15 @@ fn second_quoted(s: &str) -> Option<String> {
 }
 
 fn between_parens(s: &str) -> Option<String> {
-    let start = s.find('(')?;
-    let rest = &s[start + 1..];
-    let end = rest.find(')')?;
-    Some(rest[..end].to_string())
+    // El último paréntesis: la descripción entre comillas puede contener
+    // paréntesis propios (`Output "PNP(XXX)" (HDMI-A-2)`); el nombre del
+    // monitor es siempre el paréntesis final de la línea.
+    let start = s.rfind('(')?;
+    let end = s.rfind(')')?;
+    if end < start {
+        return None;
+    }
+    Some(s[start + 1..end].to_string())
 }
 
 /// Parsea "1920x1080 @ 60.000" (espacios opcionales alrededor del @):
@@ -415,7 +420,8 @@ fn niri_monitors() -> Vec<Monitor> {
             continue;
         }
         if line.contains("Variable refresh rate:") {
-            m.vrr = line.contains("supported");
+            // "not supported" también contiene "supported"
+            m.vrr = line.contains("supported") && !line.contains("not supported");
             continue;
         }
 

--- a/rust/preferences/src/services/fuzzel_config.rs
+++ b/rust/preferences/src/services/fuzzel_config.rs
@@ -175,10 +175,11 @@ impl FuzzelConfig {
         write_atomic(&lines);
     }
 
-    /// pkill -fuzzel (cierra la instancia actual; paridad con el Python).
+    /// Recarga fuzzel (cierra la instancia actual para que relea su config).
     pub fn reload() {
+        // OJO: `pkill -fuzzel` NO hace nada (se parsea como -f -u "zzel").
         let _ = Command::new("pkill")
-            .args(["-fuzzel"])
+            .args(["-x", "fuzzel"])
             .stdout(std::process::Stdio::null())
             .stderr(std::process::Stdio::null())
             .spawn();

--- a/rust/preferences/src/services/icons.rs
+++ b/rust/preferences/src/services/icons.rs
@@ -30,6 +30,32 @@ fn uid() -> u32 {
     1000
 }
 
+/// Socket wayland real del runtime dir (wayland-0, wayland-1, ...).
+/// Fallback al valor de la variable de entorno si existe.
+fn detect_wayland_display() -> Option<String> {
+    if let Ok(v) = std::env::var("WAYLAND_DISPLAY") {
+        if !v.is_empty() {
+            return Some(v);
+        }
+    }
+    let xrd = std::env::var("XDG_RUNTIME_DIR")
+        .unwrap_or_else(|_| format!("/run/user/{}", uid()));
+    let dir = PathBuf::from(&xrd);
+    if !dir.is_dir() {
+        return None;
+    }
+    let Ok(entries) = fs::read_dir(&dir) else {
+        return None;
+    };
+    let mut socks: Vec<String> = entries
+        .flatten()
+        .filter_map(|e| e.file_name().into_string().ok())
+        .filter(|n| n.starts_with("wayland-"))
+        .collect();
+    socks.sort();
+    socks.first().cloned()
+}
+
 /// Escribe/actualiza una clave en ~/.config/gtk-{3.0,4.0}/settings.ini
 /// (equivalente al bucle de ver/dir en IconsService.set del Python)
 fn write_gtk_ini(key: &str, value: &str) {
@@ -65,7 +91,9 @@ fn write_gtk_ini(key: &str, value: &str) {
 fn apply_live_icon_theme(theme: &str) {
     let mut env: Vec<(String, String)> = std::env::vars().collect();
     if !env.iter().any(|(k, _)| k == "WAYLAND_DISPLAY") {
-        env.push(("WAYLAND_DISPLAY".to_string(), "wayland-1".to_string()));
+        if let Some(sock) = detect_wayland_display() {
+            env.push(("WAYLAND_DISPLAY".to_string(), sock));
+        }
     }
     if !env.iter().any(|(k, _)| k == "XDG_RUNTIME_DIR") {
         env.push(("XDG_RUNTIME_DIR".to_string(), format!("/run/user/{}", uid())));

--- a/rust/preferences/src/services/keyboard.rs
+++ b/rust/preferences/src/services/keyboard.rs
@@ -32,19 +32,18 @@ pub struct Bind {
 
 /// ¿La clave coincide con el patrón del regex Python
 /// `(Mod\S*|Print|Ctrl\+Print|Alt\+Print|XF86\S*)`?
-fn key_is_recognized(key: &str) -> bool {
+pub fn is_valid_key(key: &str) -> bool {
     key.starts_with("Mod") || key == "Print" || key == "Ctrl+Print" || key == "Alt+Print" || key.starts_with("XF86")
 }
 
-/// Extrae el contenido entre el primer '"' y el siguiente '"' de `s` (s empieza con '"').
+/// Extrae el contenido desde el inicio de `s` hasta el siguiente '"'
+/// (s NO incluye la comilla de apertura: los callers hacen strip_prefix('"')).
+/// Devuelve (contenido, resto tras la comilla de cierre).
 fn split_quote(s: &str) -> (String, String) {
     let bytes = s.as_bytes();
     let mut end = 0usize;
     let mut escaped = false;
     for (i, &b) in bytes.iter().enumerate() {
-        if i == 0 {
-            continue;
-        }
         if escaped {
             escaped = false;
             continue;
@@ -61,7 +60,7 @@ fn split_quote(s: &str) -> (String, String) {
     if end == 0 {
         return (String::new(), String::new());
     }
-    (s[1..end].to_string(), s[end + 1..].to_string())
+    (s[..end].to_string(), s[end + 1..].to_string())
 }
 
 /// Equivalente a _parse_action: "spawn \"cmd\" \"args\"" | "spawn-sh \"cmd\"" | builtin.
@@ -99,17 +98,23 @@ fn parse_action(raw: &str) -> (String, String, String) {
     ("builtin".to_string(), func, args)
 }
 
+/// Escapa un string para meterlo entre comillas en KDL.
+fn kdl_escape(s: &str) -> String {
+    s.replace('\\', "\\\\").replace('"', "\\\"")
+}
+
 /// Equivalente a _make_action_line.
 fn make_action_line(bind_type: &str, command: &str, args: &str) -> String {
     match bind_type {
         "spawn" => {
+            let cmd = kdl_escape(command);
             if !args.is_empty() {
-                format!("spawn \"{command}\" \"{args}\"")
+                format!("spawn \"{cmd}\" \"{}\"", kdl_escape(args))
             } else {
-                format!("spawn \"{command}\"")
+                format!("spawn \"{cmd}\"")
             }
         }
-        "spawn-sh" => format!("spawn-sh \"{command}\""),
+        "spawn-sh" => format!("spawn-sh \"{}\"", kdl_escape(command)),
         _ => {
             if !args.is_empty() {
                 format!("{command} {args}")
@@ -147,7 +152,7 @@ fn parse_bind_line(line: &str) -> Option<Bind> {
 
     let mut tokens = head.split_whitespace();
     let key = tokens.next()?;
-    if !key_is_recognized(key) {
+    if !is_valid_key(key) {
         return None;
     }
     let allow_when_locked = tokens.any(|t| t.starts_with("allow-when-locked"));
@@ -215,7 +220,9 @@ impl KeyboardService {
         };
 
         let new_action = make_action_line(action_type, command, args);
-        let new_line = format!("    {key} {{ {new_action}; }}");
+        // Sin indent aquí: se conserva el indent original de la línea
+        // reemplazada (el Python duplicaba la indentación).
+        let new_line = format!("{key} {{ {new_action}; }}");
 
         let mut out = String::new();
         let mut in_binds = false;
@@ -267,7 +274,7 @@ impl KeyboardService {
         };
 
         let new_line = format!(
-            "    {key} {{ {}; }}",
+            "{key} {{ {}; }}",
             make_action_line(action_type, command, args)
         );
 
@@ -289,13 +296,66 @@ impl KeyboardService {
             }
         }
 
-        // Paridad con Python (insert(-1, ...)): sin bloque binds, inserta antes de la última línea
-        let pos = insert_pos.unwrap_or_else(|| out_lines.len().saturating_sub(1));
-        out_lines.insert(pos, new_line);
+        if let Some(pos) = insert_pos {
+            out_lines.insert(pos, format!("    {new_line}"));
+        } else {
+            // Sin bloque binds: crear uno al final (el Python insertaba
+            // la línea suelta fuera de cualquier bloque -> KDL inválido).
+            out_lines.push(String::new());
+            out_lines.push("binds {".to_string());
+            out_lines.push(format!("    {new_line}"));
+            out_lines.push("}".to_string());
+        }
 
         let mut result = out_lines.join("\n");
         result.push('\n');
         fs::write(&path, result).is_ok()
+    }
+
+    /// Elimina el atajo `key` del bloque `binds` de config.kdl.
+    pub fn remove_keybind(key: &str) -> bool {
+        let path = config_path();
+        if !path.exists() {
+            return false;
+        }
+        let _ = fs::copy(&path, backup_path());
+
+        let content = match fs::read_to_string(&path) {
+            Ok(c) => c,
+            Err(_) => return false,
+        };
+
+        let mut out = String::new();
+        let mut in_binds = false;
+        let mut removed = false;
+
+        for line in content.lines() {
+            let stripped = line.trim();
+            if stripped.starts_with("binds") {
+                in_binds = true;
+                out.push_str(line);
+                out.push('\n');
+                continue;
+            }
+            if in_binds && stripped == "}" {
+                out.push_str(line);
+                out.push('\n');
+                in_binds = false;
+                continue;
+            }
+            if in_binds && !removed && line_matches_key(stripped, key) {
+                removed = true;
+                continue;
+            }
+            out.push_str(line);
+            out.push('\n');
+        }
+
+        if removed {
+            fs::write(&path, out).is_ok()
+        } else {
+            false
+        }
     }
 
     /// Restaura config.kdl desde la copia de seguridad (config.kdl.bak).
@@ -307,5 +367,100 @@ impl KeyboardService {
         } else {
             false
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn split_quote_keeps_first_char() {
+        // Los callers ya quitan la comilla de apertura antes de llamar.
+        let (content, rest) = split_quote("churros-welcome\"");
+        assert_eq!(content, "churros-welcome");
+        assert!(rest.is_empty());
+
+        let (content, rest) = split_quote("foot\" \"--flag\"");
+        assert_eq!(content, "foot");
+        assert_eq!(rest, " \"--flag\"");
+    }
+
+    #[test]
+    fn parse_spawn_bind_keeps_command() {
+        let bind = parse_bind_line("    Mod+W { spawn \"churros-welcome\"; }").unwrap();
+        assert_eq!(bind.key, "Mod+W");
+        assert_eq!(bind.kind, "spawn");
+        assert_eq!(bind.command, "churros-welcome");
+        assert_eq!(bind.args, "");
+
+        let bind = parse_bind_line("    Mod+Shift+N { spawn \"churros-popup\" \"network\"; }").unwrap();
+        assert_eq!(bind.command, "churros-popup");
+        assert_eq!(bind.args, "network");
+    }
+
+    #[test]
+    fn parse_spawn_sh_keeps_command() {
+        let bind = parse_bind_line("    Mod+T { spawn-sh \"foot\"; }").unwrap();
+        assert_eq!(bind.kind, "spawn-sh");
+        assert_eq!(bind.command, "foot");
+    }
+
+    #[test]
+    fn make_action_line_escapes_quotes() {
+        assert_eq!(make_action_line("spawn", "foot", ""), "spawn \"foot\"");
+        assert_eq!(make_action_line("spawn", "cmd", "a b"), "spawn \"cmd\" \"a b\"");
+        assert_eq!(
+            make_action_line("spawn", "say", "\"hi\""),
+            "spawn \"say\" \"\\\"hi\\\"\""
+        );
+        assert_eq!(make_action_line("builtin", "close-window", ""), "close-window");
+    }
+
+    #[test]
+    fn write_path_roundtrip() {
+        // HOME temporal para no tocar la config real del usuario.
+        let tmp = std::env::temp_dir().join(format!("churros-kbd-test-{}", std::process::id()));
+        let _ = fs::remove_dir_all(&tmp);
+        let niri_dir = tmp.join(".config").join("niri");
+        fs::create_dir_all(&niri_dir).unwrap();
+        let config = niri_dir.join("config.kdl");
+        fs::write(
+            &config,
+            "layout {\n    gaps 8\n}\n\nbinds {\n    Mod+Return { spawn \"foot\"; }\n}\n",
+        )
+        .unwrap();
+        // Solo este test toca HOME (los demás no leen config_path), así que
+        // no hace falta serializar.
+        unsafe { std::env::set_var("HOME", &tmp) };
+
+        // add: debe insertarse dentro de binds con indent correcto
+        assert!(KeyboardService::add_keybind("Mod+W", "spawn", "churros-welcome", ""));
+        let content = fs::read_to_string(&config).unwrap();
+        assert!(content.contains("    Mod+W { spawn \"churros-welcome\"; }"), "add: {content}");
+
+        // set: reemplaza la acción conservando el indent (sin doble indent)
+        assert!(KeyboardService::set_keybind("Mod+W", "spawn", "churros-settings", ""));
+        let content = fs::read_to_string(&config).unwrap();
+        assert!(content.contains("    Mod+W { spawn \"churros-settings\"; }"), "set: {content}");
+        assert!(!content.contains("        Mod+W"), "set: indent duplicado: {content}");
+
+        // remove: desaparece la línea
+        assert!(KeyboardService::remove_keybind("Mod+W"));
+        let content = fs::read_to_string(&config).unwrap();
+        assert!(!content.contains("Mod+W"), "remove: {content}");
+        assert!(content.contains("Mod+Return"), "remove: borró otro bind: {content}");
+
+        // sin bloque binds: add crea el bloque en vez de escribir KDL inválido
+        let config2 = niri_dir.join("config.kdl");
+        fs::write(&config2, "layout {\n    gaps 8\n}\n").unwrap();
+        assert!(KeyboardService::add_keybind("Mod+T", "builtin", "close-window", ""));
+        let content = fs::read_to_string(&config2).unwrap();
+        assert!(
+            content.contains("binds {") && content.contains("    Mod+T { close-window; }"),
+            "sin binds: {content}"
+        );
+
+        let _ = fs::remove_dir_all(&tmp);
     }
 }

--- a/rust/preferences/src/services/lock_screen.rs
+++ b/rust/preferences/src/services/lock_screen.rs
@@ -79,14 +79,12 @@ fn which(bin: &str) -> bool {
 fn build_swaylock_cmd(data: &Value) -> Vec<String> {
     let mut cmd = vec!["swaylock".to_string()];
 
+    // swaylock (stock) no tiene "--indicator <tipo>": el anillo es el
+    // indicador por defecto y "none" se consigue con -u. "bar"/"dots"
+    // tampoco existen en stock, caen al anillo por defecto.
     let indicator = data.get("indicator").and_then(|v| v.as_str()).unwrap_or("auto");
-
-    if indicator != "auto" && !indicator.is_empty() {
-        cmd.push("-i".to_string());
-        cmd.push(indicator.to_string());
-    } else if indicator == "auto" {
-        cmd.push("-i".to_string());
-        cmd.push("ring".to_string());
+    if indicator == "none" {
+        cmd.push("-u".to_string());
     }
 
     let wp = data.get("wallpaper_path").and_then(|v| v.as_str()).unwrap_or("");
@@ -143,6 +141,14 @@ fn build_swaylock_cmd(data: &Value) -> Vec<String> {
     }
 
     cmd
+}
+
+/// Cita un argumento para sh (swayidle ejecuta el comando con sh -c).
+fn sh_quote(arg: &str) -> String {
+    if arg.chars().all(|c| c.is_ascii_alphanumeric() || "/._-+@%:".contains(c)) {
+        return arg.to_string();
+    }
+    format!("'{}'", arg.replace('\'', r"'\''"))
 }
 
 impl LockScreenService {
@@ -248,7 +254,13 @@ impl LockScreenService {
             .unwrap_or(600);
 
         let swaylock_cmd = build_swaylock_cmd(&data);
-        let joined = swaylock_cmd.join(" ").replace('\'', r"'\''");
+        // swayidle ejecuta el comando con sh -c: citar cada argumento
+        // (el font por defecto contiene espacios y rompía el comando).
+        let joined = swaylock_cmd
+            .iter()
+            .map(|a| sh_quote(a))
+            .collect::<Vec<_>>()
+            .join(" ");
 
         // swayidle -w timeout <segundos> "<comando swaylock>"
         let mut cmd = Command::new("swayidle");

--- a/rust/preferences/src/services/logs_service.rs
+++ b/rust/preferences/src/services/logs_service.rs
@@ -20,9 +20,9 @@ fn run_with_timeout(args: &[&str], timeout_secs: u64) -> Option<std::process::Ou
         .ok()?;
 
     let deadline = Instant::now() + Duration::from_secs(timeout_secs);
-    loop {
+    let status = loop {
         match child.try_wait() {
-            Ok(Some(_)) => break,
+            Ok(Some(st)) => break st,
             Ok(None) => {
                 if Instant::now() >= deadline {
                     let _ = child.kill();
@@ -33,7 +33,7 @@ fn run_with_timeout(args: &[&str], timeout_secs: u64) -> Option<std::process::Ou
             }
             Err(_) => return None,
         }
-    }
+    };
 
     let mut stdout = Vec::new();
     let mut stderr = Vec::new();
@@ -46,7 +46,7 @@ fn run_with_timeout(args: &[&str], timeout_secs: u64) -> Option<std::process::Ou
     let _ = child.wait();
 
     Some(std::process::Output {
-        status: std::process::ExitStatus::default(),
+        status,
         stdout,
         stderr,
     })

--- a/rust/preferences/src/services/mako_config.rs
+++ b/rust/preferences/src/services/mako_config.rs
@@ -113,7 +113,11 @@ fn get_key_opt(section: &str, key: &str) -> Option<String> {
 
 fn get_key_bool(section: &str, key: &str, default: bool) -> bool {
     match get_key_opt(section, key) {
-        Some(v) => v == "true",
+        // mako acepta true/false/yes/no/1/0
+        Some(v) => matches!(
+            v.trim().to_ascii_lowercase().as_str(),
+            "true" | "yes" | "1" | "on"
+        ),
         None => default,
     }
 }

--- a/rust/preferences/src/services/mod.rs
+++ b/rust/preferences/src/services/mod.rs
@@ -19,6 +19,7 @@ pub mod night_light;
 pub mod niri_config;
 pub mod power;
 pub mod privacy;
+pub mod pywal;
 pub mod settings;
 pub mod system;
 pub mod theme;

--- a/rust/preferences/src/services/niri_config.rs
+++ b/rust/preferences/src/services/niri_config.rs
@@ -259,9 +259,13 @@ impl NiriConfig {
         write_atomic(&lines.join("\n"));
     }
 
+    /// Recarga la config de niri en vivo (equivalente a reload()).
+    /// OJO: NO usar pkill -HUP niri — SIGHUP reinicia la sesión entera
+    /// del compositor (mata todas las apps); la forma correcta es
+    /// `niri msg action load-config-file`.
     pub fn reload() {
-        let _ = Command::new("pkill")
-            .args(["-HUP", "niri"])
+        let _ = Command::new("niri")
+            .args(["msg", "action", "load-config-file"])
             .stdout(std::process::Stdio::null())
             .stderr(std::process::Stdio::null())
             .spawn();
@@ -600,7 +604,7 @@ impl NiriConfig {
                 None => create_block(
                     &content,
                     &["blur"],
-                    &["passes 2", "offset 2.0", "noise 0.0", "saturation 1.2"],
+                    &["passes 3", "offset 3.0", "noise 0.0", "saturation 1.3"],
                 ),
             };
             write_atomic(&result);
@@ -703,12 +707,87 @@ impl NiriConfig {
 
     // ------------------------------------------------- Performance mode
 
-    /// Modo rendimiento: desactiva blur + animaciones
+    /// Marcadores del bloque de blur de las apps ChurrOS en config.kdl
+    /// (ver archiso/airootfs/etc/skel/.config/niri/config.kdl).
+    const GLASS_START: &'static str = "[CHURROS-GLASS-START]";
+    const GLASS_END: &'static str = "[CHURROS-GLASS-END]";
+
+    /// Byte bounds de la región entre las líneas de marcador (exclusivas).
+    /// Se busca el marcador como LÍNEA completa para que las menciones
+    /// en comentarios descriptivos no confundan el matcher.
+    fn glass_bounds(content: &str) -> Option<(usize, usize)> {
+        let start_marker = "\n// [CHURROS-GLASS-START]\n";
+        let end_marker = "\n// [CHURROS-GLASS-END]";
+        let start = content.find(start_marker)? + start_marker.len();
+        let end = start + content[start..].find(end_marker)?;
+        Some((start, end))
+    }
+
+    /// Devuelve si el blur de las window rules de ChurrOS está activo
+    /// (None si el config no tiene los marcadores).
+    fn get_glass_blur(content: &str) -> Option<bool> {
+        let (start, end) = Self::glass_bounds(content)?;
+        for line in content[start..end].lines() {
+            match line.trim() {
+                "blur true" => return Some(true),
+                "blur false" => return Some(false),
+                _ => {}
+            }
+        }
+        Some(false)
+    }
+
+    /// Toggle blur true <-> blur false SOLO en líneas exactas dentro del
+    /// bloque marcado (los comentarios que mencionen blur no se tocan).
+    fn set_glass_blur(content: &str, enabled: bool) -> Option<String> {
+        let (start, end) = Self::glass_bounds(content)?;
+        let region = &content[start..end];
+        let had_trailing_nl = region.ends_with('\n');
+        let mut new_region: String = region
+            .lines()
+            .map(|line| {
+                let stripped = line.trim();
+                if !enabled && stripped == "blur true" {
+                    line.replacen("blur true", "blur false", 1)
+                } else if enabled && stripped == "blur false" {
+                    line.replacen("blur false", "blur true", 1)
+                } else {
+                    line.to_string()
+                }
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+        if had_trailing_nl {
+            new_region.push('\n');
+        }
+        Some(format!(
+            "{}{}{}",
+            &content[..start],
+            new_region,
+            &content[end..]
+        ))
+    }
+
+    /// Modo rendimiento: desactiva blur (window rules de ChurrOS) + animaciones.
     pub fn get_performance_mode() -> bool {
-        !Self::get_blur_enabled() && !Self::get_animations()
+        let content = read();
+        let glass_off = match Self::get_glass_blur(&content) {
+            Some(active) => !active,
+            // Config sin marcadores: criterio antiguo (bloque blur ausente)
+            None => !Self::get_blur_enabled(),
+        };
+        !Self::get_animations() && glass_off
     }
 
     pub fn set_performance_mode(on: bool) {
+        // El blur real de las apps vive en las window rules (marcadas con
+        // [CHURROS-GLASS-*]): quitarlo ahí es lo que lo desactiva de verdad.
+        let content = read();
+        if let Some(new_content) = Self::set_glass_blur(&content, !on) {
+            write_atomic(&new_content);
+        }
+        // El bloque global `blur { ... }` solo es tuning; se conserva el
+        // comportamiento anterior (borrar al activar, restaurar al quitar).
         Self::set_blur_enabled(!on);
         Self::set_animations(!on);
     }
@@ -730,4 +809,44 @@ fn first_quoted(line: &str) -> Option<String> {
     let rest = &line[start..];
     let end = rest.find('"')?;
     Some(rest[..end].to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// config.kdl real de la ISO (skel): debe tener los marcadores de glass.
+    fn real_config() -> &'static str {
+        const PATH: &str = concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../archiso/airootfs/etc/skel/.config/niri/config.kdl"
+        );
+        let content = fs::read_to_string(PATH).expect("leer config.kdl del skel");
+        Box::leak(content.into_boxed_str())
+    }
+
+    #[test]
+    fn real_config_has_glass_markers() {
+        let content = real_config();
+        assert!(content.contains(NiriConfig::GLASS_START), "falta [CHURROS-GLASS-START]");
+        assert!(content.contains(NiriConfig::GLASS_END), "falta [CHURROS-GLASS-END]");
+        assert_eq!(NiriConfig::get_glass_blur(content), Some(true));
+    }
+
+    #[test]
+    fn glass_blur_toggle_roundtrip() {
+        let content = real_config();
+        let off = NiriConfig::set_glass_blur(content, false).expect("toggle off");
+        assert_eq!(NiriConfig::get_glass_blur(&off), Some(false));
+        assert!(off.contains("blur false"));
+
+        let on = NiriConfig::set_glass_blur(&off, true).expect("toggle on");
+        assert_eq!(NiriConfig::get_glass_blur(&on), Some(true));
+        assert!(on.contains("blur true"));
+
+        // Idempotente
+        assert_eq!(off, NiriConfig::set_glass_blur(&off, false).unwrap());
+        // El resto del config no cambia
+        assert_eq!(on.lines().count(), content.lines().count());
+    }
 }

--- a/rust/preferences/src/services/niri_config.rs
+++ b/rust/preferences/src/services/niri_config.rs
@@ -131,29 +131,55 @@ fn update_value_in_block(content: &str, path: &[&str], key: &str, value: &str) -
 }
 
 /// Crea el bloque `path` al final del config, creando los padres que falten.
+/// Crea el bloque `path` (y los padres que falten), con `body_lines` como
+/// contenido del bloque más profundo. Si algún padre ya existe, el bloque
+/// nuevo se anida dentro de él; si no existe ninguno, se añade al final.
+/// (La versión anterior creaba el padre vacío y perdía el hijo.)
 fn create_block(content: &str, path: &[&str], body_lines: &[&str]) -> String {
-    let mut content = content.to_string();
-
+    // Profundidad del prefijo que ya existe.
+    let mut existing_depth = 0usize;
     for i in 1..=path.len() {
-        let sub_path = &path[..i];
-        if find_nested_block(&content, sub_path).is_none() {
-            let indent = "    ".repeat(i - 1);
-            let lines: &[&str] = if i == path.len() { body_lines } else { &[] };
-
-            let mut block = format!("{indent}{} {{\n", sub_path[i - 1]);
-            for ln in lines {
-                block += &format!("{indent}    {ln}\n");
-            }
-            block += &format!("{indent}}}\n");
-
-            if !content.is_empty() && !content.ends_with('\n') {
-                content.push('\n');
-            }
-            content.push_str(&block);
-            return content;
+        if find_nested_block(content, &path[..i]).is_some() {
+            existing_depth = i;
+        } else {
+            break;
         }
     }
-    content
+
+    if existing_depth == path.len() {
+        return content.to_string();
+    }
+
+    // Construir los bloques que faltan, de adentro hacia afuera.
+    let mut inner = String::new();
+    let deepest_indent = "    ".repeat(path.len());
+    for ln in body_lines {
+        inner.push_str(&format!("{deepest_indent}{ln}\n"));
+    }
+    for i in (existing_depth..path.len()).rev() {
+        let indent = "    ".repeat(i);
+        let head = path[i];
+        inner = format!("{indent}{head} {{\n{inner}{indent}}}\n");
+    }
+
+    if existing_depth > 0 {
+        // Anidar justo antes del cierre del padre existente.
+        let (_, parent_end) = find_nested_block(content, &path[..existing_depth]).unwrap();
+        let lines: Vec<&str> = content.lines().collect();
+        let mut out: Vec<String> = lines[..parent_end].iter().map(|s| s.to_string()).collect();
+        for l in inner.lines() {
+            out.push(l.to_string());
+        }
+        out.extend(lines[parent_end..].iter().map(|s| s.to_string()));
+        out.join("\n")
+    } else {
+        let mut c = content.to_string();
+        if !c.is_empty() && !c.ends_with('\n') {
+            c.push('\n');
+        }
+        c.push_str(&inner);
+        c
+    }
 }
 
 /// Extrae el valor de `key` dentro del bloque `block_path` (getters).
@@ -204,59 +230,30 @@ fn py_float_str(v: f64) -> String {
 }
 
 impl NiriConfig {
-    /// pkill -HUP niri (recarga la config en vivo)
+    /// Actualiza `input { keyboard { xkb { layout "..." } } }` (o lo crea).
+    /// La versión anterior usaba una clave plana `xkb-layout` que no existe
+    /// en el config y además rompía con sub-bloques anidados.
     pub fn set_keyboard_layout(layout: &str) {
-        // Añade/actualiza "xkb-layout" en el bloque input del config.kdl
         let content = read();
-        let lines: Vec<String> = content.lines().map(|s| s.to_string()).collect();
 
-        // Buscar bloque "input {"
-        let mut start = None;
-        let mut depth = 0i32;
-        for (i, raw) in lines.iter().enumerate() {
-            let stripped = raw.trim();
-            if start.is_none() && stripped.starts_with("input") && stripped.contains('{') {
-                start = Some(i);
-                depth = 1;
-                continue;
-            }
-            if start.is_some() {
-                depth += stripped.matches('{').count() as i32;
-                depth -= stripped.matches('}').count() as i32;
-                if depth <= 0 {
-                    break;
-                }
-            }
-        }
-        let Some(s) = start else {
-            // No hay bloque input: añadirlo al final
-            let mut content = content;
-            if !content.ends_with('\n') {
-                content.push('\n');
-            }
-            content.push_str(&format!("input {{\n    xkb-layout \"{layout}\"\n}}\n"));
-            write_atomic(&content);
+        // Editar `layout "..."` dentro de input > keyboard > xkb.
+        if let Some(updated) = update_value_in_block(
+            &content,
+            &["input", "keyboard", "xkb"],
+            "layout",
+            &format!("\"{layout}\""),
+        ) {
+            write_atomic(&updated);
             return;
-        };
+        }
 
-        // Reemplazar/insertar la línea xkb-layout dentro del bloque
-        let mut lines = lines;
-        let mut replaced = false;
-        for j in s + 1..lines.len() {
-            let stripped = lines[j].trim();
-            if stripped.starts_with('}') {
-                break;
-            }
-            if stripped.starts_with("xkb-layout") {
-                lines[j] = format!("    xkb-layout \"{layout}\"");
-                replaced = true;
-                break;
-            }
-        }
-        if !replaced {
-            lines.insert(s + 1, format!("    xkb-layout \"{layout}\""));
-        }
-        write_atomic(&lines.join("\n"));
+        // No existe el bloque xkb: crearlo anidado (con sus padres).
+        let result = create_block(
+            &content,
+            &["input", "keyboard", "xkb"],
+            &[&format!("layout \"{layout}\"")],
+        );
+        write_atomic(&result);
     }
 
     /// Recarga la config de niri en vivo (equivalente a reload()).
@@ -848,5 +845,36 @@ mod tests {
         assert_eq!(off, NiriConfig::set_glass_blur(&off, false).unwrap());
         // El resto del config no cambia
         assert_eq!(on.lines().count(), content.lines().count());
+    }
+
+    #[test]
+    fn create_block_nested_preserves_parent_and_child() {
+        let content = "layout {\n    gaps 8\n}\n";
+        // El padre "layout" existe; se debe anidar "border" dentro con su cuerpo.
+        let out = create_block(content, &["layout", "border"], &["on"]);
+        assert!(out.contains("layout {"), "falta layout: {out}");
+        assert!(out.contains("    border {"), "border no anidado: {out}");
+        assert!(out.contains("        on"), "falta cuerpo on: {out}");
+        assert!(out.contains("gaps 8"), "se perdio gaps: {out}");
+    }
+
+    #[test]
+    fn create_block_creates_full_path_when_missing() {
+        let content = "";
+        let out = create_block(content, &["input", "keyboard", "xkb"], &["layout \"us\""]);
+        assert!(out.contains("input {"));
+        assert!(out.contains("    keyboard {"));
+        assert!(out.contains("        xkb {"));
+        assert!(out.contains("            layout \"us\""));
+    }
+
+    #[test]
+    fn update_value_in_block_updates_nested_xkb() {
+        let content =
+            "input {\n    keyboard {\n        xkb {\n            layout \"us\"\n        }\n    }\n}\n";
+        let updated = update_value_in_block(content, &["input", "keyboard", "xkb"], "layout", "\"es\"")
+            .expect("actualizar layout");
+        assert!(updated.contains("layout \"es\""), "no actualizo layout: {updated}");
+        assert!(!updated.contains("layout \"us\""), "no quito el layout viejo: {updated}");
     }
 }

--- a/rust/preferences/src/services/power.rs
+++ b/rust/preferences/src/services/power.rs
@@ -59,22 +59,28 @@ fn run_no_output(args: &[&str]) {
 
 pub struct PowerService;
 
+/// Ruta del primer dispositivo de batería de `upower -e`
+/// (línea que termina en "battery": BAT0, CMB0, hidpp_battery_*, etc.).
+fn battery_device() -> Option<String> {
+    let output = run(&["upower", "-e"]);
+    output
+        .lines()
+        .find(|l| l.trim().ends_with("battery"))
+        .map(|l| l.trim().to_string())
+}
+
 impl PowerService {
     /// True si hay una batería detectada (upower -e termina en "battery").
     pub fn battery_present() -> bool {
-        let output = run(&["upower", "-e"]);
-        if output.is_empty() {
-            return false;
-        }
-        output.lines().any(|l| l.trim().ends_with("battery"))
+        battery_device().is_some()
     }
 
     /// Porcentaje de carga (0-100); si no hay batería/upower falla -> 100.
     pub fn battery_percentage() -> i64 {
-        let mut output = run(&["upower", "-i", "/org/freedesktop/UPower/devices/battery_BAT0"]);
-        if output.is_empty() {
-            output = run(&["upower", "-i", "/org/freedesktop/UPower/devices/battery_BAT1"]);
-        }
+        let Some(device) = battery_device() else {
+            return 100;
+        };
+        let output = run(&["upower", "-i", &device]);
         for line in output.lines() {
             if line.contains("percentage") {
                 if let Some((_, v)) = line.split_once(':') {
@@ -92,10 +98,10 @@ impl PowerService {
     /// NOTA: el docstring del Python dice 'Cargando'/'Descargando'/'Llena' pero
     /// el codigo devuelve el valor crudo en ingles; se porta el comportamiento real.
     pub fn battery_state() -> String {
-        let mut output = run(&["upower", "-i", "/org/freedesktop/UPower/devices/battery_BAT0"]);
-        if output.is_empty() {
-            output = run(&["upower", "-i", "/org/freedesktop/UPower/devices/battery_BAT1"]);
-        }
+        let Some(device) = battery_device() else {
+            return "Desconocido".to_string();
+        };
+        let output = run(&["upower", "-i", &device]);
         for line in output.lines() {
             if line.contains("state") {
                 if let Some((_, v)) = line.split_once(':') {
@@ -121,9 +127,13 @@ impl PowerService {
         let output = run(&["powerprofilesctl", "list"]);
         let mut profiles = Vec::new();
         for line in output.lines() {
-            let t = line.trim();
+            // `powerprofilesctl list` imprime `  performance:` (con ":") y un
+            // `*` en el activo; el match exacto fallaba por los dos puntos.
+            let t = line.trim().trim_end_matches(':').trim();
             if matches!(t, "performance" | "balanced" | "power-saver") {
-                profiles.push(t.to_string());
+                if !profiles.contains(&t.to_string()) {
+                    profiles.push(t.to_string());
+                }
             }
         }
         if profiles.is_empty() {

--- a/rust/preferences/src/services/privacy.rs
+++ b/rust/preferences/src/services/privacy.rs
@@ -66,20 +66,34 @@ impl PrivacyService {
         let action = if value { "enable" } else { "disable" };
         let ufw_action = if value { "enable" } else { "disable" };
 
-        if getuid() == 0 {
-            let _ = Command::new("systemctl")
-                .args([action, "ufw.service"])
-                .status();
-            let _ = Command::new("ufw").args(["--force", ufw_action]).status();
+        let (mut cmd_systemctl, mut cmd_ufw) = if getuid() == 0 {
+            (
+                Command::new("systemctl"),
+                Command::new("ufw"),
+            )
         } else {
-            let _ = Command::new("pkexec")
-                .args(["systemctl", action, "ufw.service"])
-                .status();
-            let _ = Command::new("pkexec")
-                .args(["ufw", "--force", ufw_action])
-                .status();
-        }
-        true
+            (Command::new("pkexec"), Command::new("pkexec"))
+        };
+        let systemctl_ok = cmd_systemctl
+            .args(if getuid() == 0 {
+                vec![action, "ufw.service"]
+            } else {
+                vec!["systemctl", action, "ufw.service"]
+            })
+            .status()
+            .map(|s| s.success())
+            .unwrap_or(false);
+        let ufw_ok = cmd_ufw
+            .args(if getuid() == 0 {
+                vec!["--force", ufw_action]
+            } else {
+                vec!["ufw", "--force", ufw_action]
+            })
+            .status()
+            .map(|s| s.success())
+            .unwrap_or(false);
+
+        systemctl_ok && ufw_ok
     }
 
     #[allow(dead_code)] // portado por paridad; sin uso en las páginas actuales

--- a/rust/preferences/src/services/pywal.rs
+++ b/rust/preferences/src/services/pywal.rs
@@ -1,0 +1,136 @@
+// ==========================================
+// PywalService — colores dinámicos desde el wallpaper
+// (equivalente a services/pywal_service.py)
+// ==========================================
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use serde_json::{json, Value};
+
+use crate::services::accent::AccentService;
+use crate::services::settings;
+use crate::services::wallpaper::WallpaperService;
+use crate::services::waybar::WaybarService;
+
+pub struct PywalService;
+
+fn home() -> PathBuf {
+    let home = std::env::var("HOME").unwrap_or_else(|_| "/root".to_string());
+    PathBuf::from(home)
+}
+
+fn cache_file() -> PathBuf {
+    home().join(".cache").join("wal").join("colors.json")
+}
+
+fn which(name: &str) -> bool {
+    let path_var = std::env::var("PATH").unwrap_or_default();
+    path_var
+        .split(':')
+        .any(|dir| Path::new(dir).join(name).is_file())
+}
+
+impl PywalService {
+    pub fn available() -> bool {
+        which("wal")
+    }
+
+    pub fn enabled() -> bool {
+        settings::get_bool("theme.dynamic_colors", false)
+    }
+
+    fn current_wallpaper() -> Option<String> {
+        let path = WallpaperService::current();
+        if !path.is_empty() && Path::new(&path).is_file() {
+            return Some(path);
+        }
+        let default = "/usr/share/churros/wallpapers/default.jpeg";
+        if Path::new(default).is_file() {
+            return Some(default.to_string());
+        }
+        None
+    }
+
+    /// Corre `wal -i <wallpaper>` y devuelve la paleta (colors.json) o None.
+    pub fn generate() -> Option<Value> {
+        let wallpaper = Self::current_wallpaper()?;
+        if !Self::available() {
+            return None;
+        }
+        let _ = std::process::Command::new("wal")
+            .args(["-q", "-i", &wallpaper, "-n", "-e"])
+            .status();
+        Self::read_cache()
+    }
+
+    fn read_cache() -> Option<Value> {
+        let raw = fs::read_to_string(cache_file()).ok()?;
+        serde_json::from_str(&raw).ok()
+    }
+
+    /// Aplica la paleta: accent GTK (accent.css) + colores de waybar.
+    pub fn apply_accent(palette: &Value) -> bool {
+        let colors = palette.get("colors").and_then(|c| c.as_object());
+        let specials = palette.get("special").and_then(|c| c.as_object());
+
+        let get_color = |name: &str| -> Option<&str> {
+            colors
+                .and_then(|c| c.get(name))
+                .and_then(|v| v.as_str())
+        };
+        let get_special = |name: &str| -> Option<&str> {
+            specials
+                .and_then(|s| s.get(name))
+                .and_then(|v| v.as_str())
+        };
+
+        // Acento: color vivo de la paleta (color1 -> color4 -> foreground)
+        let accent = get_color("color1")
+            .or_else(|| get_color("color4"))
+            .or_else(|| get_special("foreground"))
+            .unwrap_or("#DE8636");
+        let bg = get_special("background").unwrap_or("#111827");
+        let fg = get_special("foreground").unwrap_or("#F8FAFC");
+
+        // Acento GTK (accent.css)
+        AccentService::set_hex(accent);
+
+        // Waybar: colors-waybar.css + recarga
+        WaybarService::apply_pywal_colors(bg, fg, accent);
+
+        true
+    }
+
+    /// Habilita/deshabilita los colores dinámicos.
+    pub fn toggle(value: bool) -> bool {
+        if value {
+            Self::enable()
+        } else {
+            settings::set("theme.dynamic_colors", json!(false));
+            // Volver al color guardado por nombre
+            AccentService::set(&AccentService::current());
+            true
+        }
+    }
+
+    fn enable() -> bool {
+        settings::set("theme.dynamic_colors", json!(true));
+        let Some(palette) = Self::generate() else {
+            return false;
+        };
+        Self::apply_accent(&palette)
+    }
+
+    /// Hook de WallpaperService.set: si los colores dinámicos están activos,
+    /// regenera la paleta desde el wallpaper y la aplica.
+    pub fn regenerate_if_enabled() -> bool {
+        if !Self::enabled() {
+            return false;
+        }
+        let Some(palette) = Self::generate() else {
+            return false;
+        };
+        Self::apply_accent(&palette)
+    }
+}

--- a/rust/preferences/src/services/settings.rs
+++ b/rust/preferences/src/services/settings.rs
@@ -43,9 +43,14 @@ fn ensure() {
 
 pub fn load() -> Value {
     ensure();
-    match fs::read_to_string(config_file()) {
-        Ok(content) => serde_json::from_str(&content).unwrap_or_else(|_| defaults()),
-        Err(_) => defaults(),
+    let Ok(content) = fs::read_to_string(config_file()) else {
+        return defaults();
+    };
+    match serde_json::from_str::<Value>(&content) {
+        Ok(v @ Value::Object(_)) => v,
+        // JSON válido pero con raíz no-objeto ([] , "x", 42...): recuperarse
+        // con defaults en vez de paniquear dentro de set().
+        _ => defaults(),
     }
 }
 
@@ -90,7 +95,10 @@ pub fn get_bool(key: &str, default: bool) -> bool {
 
 pub fn set(key: &str, value: Value) {
     let mut data = load();
-    let mut current = data.as_object_mut().expect("settings.json raíz debe ser objeto");
+    let Some(mut current) = data.as_object_mut() else {
+        // load() garantiza una raíz objeto, pero nunca paniquear aquí.
+        return;
+    };
 
     let mut parts: Vec<&str> = key.split('.').collect();
     let last = parts.pop().unwrap();

--- a/rust/preferences/src/services/theme.rs
+++ b/rust/preferences/src/services/theme.rs
@@ -3,6 +3,7 @@
 // (equivalente a services/theme.py)
 // ==========================================
 
+use std::cell::RefCell;
 use std::fs;
 use std::path::PathBuf;
 use std::process::Command;
@@ -10,6 +11,14 @@ use std::process::Command;
 use serde_json::json;
 
 use crate::services::settings;
+
+// Listeners de cambio de tema (dark/light). El patrón es el mismo que
+// Search::connect_search: los registra la ventana y ThemeService::set los
+// invoca al final para refrescar el tema en vivo sin depender de gsettings/
+// dconf/DBus. Todo corre en el hilo principal de GTK.
+thread_local! {
+    static THEME_LISTENERS: RefCell<Vec<Box<dyn Fn(bool)>>> = RefCell::new(Vec::new());
+}
 
 fn cache_dir() -> PathBuf {
     let home = std::env::var("HOME").unwrap_or_else(|_| "/root".to_string());
@@ -64,25 +73,72 @@ fn libc_getuid() -> u32 {
     1000
 }
 
+/// Actualiza SOLO las claves de tema en el ini, preservando el resto
+/// (cursor, fuente, etc.). El Python sobrescribía el archivo entero y
+/// perdía las claves que escriben otras páginas (p. ej. cursor.rs).
+fn update_ini_key(ini: &PathBuf, key: &str, value: &str) {
+    if let Some(parent) = ini.parent() {
+        let _ = fs::create_dir_all(parent);
+    }
+    let existing = fs::read_to_string(ini).unwrap_or_default();
+    let mut lines: Vec<String> = existing.lines().map(|s| s.to_string()).collect();
+
+    let mut seen = false;
+    for line in lines.iter_mut() {
+        if line.trim_start().starts_with(&format!("{key}=")) {
+            *line = format!("{key}={value}");
+            seen = true;
+        }
+    }
+    if !seen {
+        lines.push(format!("{key}={value}"));
+    }
+
+    let joined = lines.join("\n");
+    let content = if joined.contains("[Settings]") {
+        joined
+    } else {
+        format!("[Settings]\n{joined}")
+    };
+    let _ = fs::write(ini, content + "\n");
+}
+
 fn write_gtk_settings(dark: bool) {
     let home = std::env::var("HOME").unwrap_or_else(|_| "/root".to_string());
     let icon_theme = settings::get_string("icons.theme", if dark { "Papirus-Dark" } else { "Papirus" });
-
     let gtk_theme = if dark { "Adwaita-dark" } else { "Adwaita" };
 
     for dir in ["gtk-3.0", "gtk-4.0"] {
-        let path = PathBuf::from(&home).join(".config").join(dir).join("settings.ini");
-        if let Some(parent) = path.parent() {
-            let _ = fs::create_dir_all(parent);
-        }
-        let content = format!(
-            "[Settings]\ngtk-theme-name={}\ngtk-application-prefer-dark-theme={}\ngtk-icon-theme-name={}\n",
-            gtk_theme,
-            u8::from(dark),
-            icon_theme
+        let ini = PathBuf::from(&home).join(".config").join(dir).join("settings.ini");
+        update_ini_key(&ini, "gtk-theme-name", gtk_theme);
+        update_ini_key(
+            &ini,
+            "gtk-application-prefer-dark-theme",
+            if dark { "1" } else { "0" },
         );
-        let _ = fs::write(path, content);
+        update_ini_key(&ini, "gtk-icon-theme-name", &icon_theme);
     }
+
+    // Mecanismo en vivo de GTK4: color-scheme via gsettings (el portal de
+    // settings lo propaga y el listener de window.rs refresca la clase CSS
+    // "light" sin reiniciar la app). El gtk-theme-name de settings.ini solo
+    // aplica al arrancar; cambiarlo en caliente puede re-tematizar a medias.
+    let _ = Command::new("gsettings")
+        .args([
+            "set",
+            "org.gnome.desktop.interface",
+            "color-scheme",
+            if dark { "prefer-dark" } else { "default" },
+        ])
+        .output();
+    let _ = Command::new("gsettings")
+        .args([
+            "set",
+            "org.gnome.desktop.interface",
+            "gtk-theme",
+            gtk_theme,
+        ])
+        .output();
 
     // Flag en caché para que is_dark() sea rápido sin leer settings.json
     if let Some(parent) = dark_flag().parent() {
@@ -125,9 +181,53 @@ impl ThemeService {
             .output();
 
         // TODO: pywal integration (services/pywal_service.py)
+
+        // Colores dinámicos: regenerar paleta si pywal está activo (paridad
+        // con theme.py del Python).
+        if crate::services::pywal::PywalService::enabled() {
+            let _ = crate::services::pywal::PywalService::regenerate_if_enabled();
+        }
+
+        // Notificar en vivo a la ventana (refresh_theme) sin round-trip
+        // externo: mismo hook que _refresh_root_theme() del Python.
+        Self::notify(dark);
+    }
+
+    /// Registra un callback que se invoca en cada cambio de tema.
+    pub fn on_change(cb: impl Fn(bool) + 'static) {
+        THEME_LISTENERS.with(|l| l.borrow_mut().push(Box::new(cb)));
+    }
+
+    fn notify(dark: bool) {
+        THEME_LISTENERS.with(|l| {
+            for cb in l.borrow().iter() {
+                cb(dark);
+            }
+        });
     }
 
     pub fn toggle() {
         Self::set(!Self::is_dark());
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::cell::RefCell;
+    use std::rc::Rc;
+
+    #[test]
+    fn on_change_notifies_listeners() {
+        let received = Rc::new(RefCell::new(Vec::new()));
+        let r1 = received.clone();
+        ThemeService::on_change(move |dark| r1.borrow_mut().push(dark));
+        let r2 = received.clone();
+        ThemeService::on_change(move |dark| r2.borrow_mut().push(dark));
+
+        ThemeService::notify(true);
+        ThemeService::notify(false);
+
+        assert_eq!(*received.borrow(), vec![true, true, false, false]);
     }
 }

--- a/rust/preferences/src/services/users.rs
+++ b/rust/preferences/src/services/users.rs
@@ -4,7 +4,6 @@
 // ==========================================
 
 use std::fs;
-use std::path::PathBuf;
 use std::process::Command;
 
 pub struct UsersService;
@@ -169,18 +168,28 @@ impl UsersService {
             return true;
         }
 
-        let path = PathBuf::from(GREETD_PATH);
-        let directory = path.parent().unwrap_or(std::path::Path::new("/etc"));
-        let tmp = directory.join(format!(
-            "greetd-{}.toml.tmp",
-            std::process::id()
-        ));
-        if fs::write(&tmp, &new_content).is_ok() {
-            if fs::rename(&tmp, &path).is_ok() {
-                return true;
-            }
-            let _ = fs::remove_file(&tmp);
+        // /etc/greetd no es escribible por el usuario: escribir a un temporal
+        // propio y copiarlo con privilegios (churros-pkexec: pkexec/sudo -n).
+        // El patrón es el mismo que usa datetime.rs con timedatectl.
+        let tmp = std::env::temp_dir().join(format!("churros-greetd-{}.toml", std::process::id()));
+        if fs::write(&tmp, &new_content).is_err() {
+            return false;
         }
-        false
+        let tmp_str = tmp.to_string_lossy().to_string();
+        let ok = if getuid() == 0 {
+            Command::new("install")
+                .args(["-m", "644", &tmp_str, GREETD_PATH])
+                .status()
+                .map(|s| s.success())
+                .unwrap_or(false)
+        } else {
+            Command::new("churros-pkexec")
+                .args(["install", "-m", "644", &tmp_str, GREETD_PATH])
+                .status()
+                .map(|s| s.success())
+                .unwrap_or(false)
+        };
+        let _ = fs::remove_file(&tmp);
+        ok
     }
 }

--- a/rust/preferences/src/services/users.rs
+++ b/rust/preferences/src/services/users.rs
@@ -64,6 +64,16 @@ fn line_has_command_eq(line: &str) -> bool {
     t["command".len()..].trim_start().starts_with('=')
 }
 
+/// ¿La línea inicia una sección `[nombre]`? Devuelve el nombre.
+fn section_name(line: &str) -> Option<&str> {
+    let t = line.trim();
+    if t.starts_with('[') && t.ends_with(']') {
+        Some(&t[1..t.len() - 1])
+    } else {
+        None
+    }
+}
+
 impl UsersService {
     pub fn username() -> String {
         std::env::var("USER").unwrap_or_else(|_| {
@@ -113,12 +123,24 @@ impl UsersService {
             .unwrap_or_else(|_| "Desconocido".to_string())
     }
 
-    /// ¿Hay autologin configurado en greetd? (regex ^\s*command\s*=\s*"[^"]+")
+    /// ¿Hay autologin configurado en greetd? Solo cuenta la sección
+    /// `[default_session]` (un `command` en `[terminal]`/`[initial_session]`
+    /// no es autologin).
     pub fn auto_login() -> bool {
-        match fs::read_to_string(GREETD_PATH) {
-            Ok(content) => content.lines().any(line_is_command),
-            Err(_) => false,
+        let Ok(content) = fs::read_to_string(GREETD_PATH) else {
+            return false;
+        };
+        let mut in_default = false;
+        for line in content.lines() {
+            if let Some(sec) = section_name(line) {
+                in_default = sec == "default_session";
+                continue;
+            }
+            if in_default && line_is_command(line) {
+                return true;
+            }
         }
+        false
     }
 
     /// Activa/desactiva el autologin editando /etc/greetd/config.toml
@@ -128,7 +150,19 @@ impl UsersService {
             return false;
         };
 
-        let has_command = content.lines().any(line_has_command_eq);
+        // ¿Hay un `command` dentro de [default_session]?
+        let mut has_command = false;
+        let mut in_default = false;
+        for line in content.lines() {
+            if let Some(sec) = section_name(line) {
+                in_default = sec == "default_session";
+                continue;
+            }
+            if in_default && line_has_command_eq(line) {
+                has_command = true;
+                break;
+            }
+        }
 
         if value && has_command {
             return true;
@@ -156,12 +190,23 @@ impl UsersService {
                 format!("{content}\n[default_session]\ncommand = \"/usr/bin/niri\"\n")
             }
         } else {
-            // Quitar la primera línea command = "..." (regex multilinea)
-            let mut lines: Vec<String> = content.lines().map(|s| s.to_string()).collect();
-            if let Some(pos) = lines.iter().position(|l| line_is_command(l)) {
-                lines.remove(pos);
+            // Quitar la línea `command = "..."` SOLO dentro de [default_session]
+            let mut out: Vec<String> = Vec::with_capacity(content.lines().count());
+            let mut in_default = false;
+            let mut removed = false;
+            for line in content.lines() {
+                if let Some(sec) = section_name(line) {
+                    in_default = sec == "default_session";
+                    out.push(line.to_string());
+                    continue;
+                }
+                if in_default && !removed && line_is_command(line) {
+                    removed = true;
+                    continue;
+                }
+                out.push(line.to_string());
             }
-            lines.join("\n")
+            out.join("\n")
         };
 
         if new_content == content {

--- a/rust/preferences/src/services/wallpaper.rs
+++ b/rust/preferences/src/services/wallpaper.rs
@@ -63,6 +63,51 @@ fn which(name: &str) -> bool {
     path_var.split(':').any(|dir| Path::new(dir).join(name).is_file())
 }
 
+/// Ejecuta un comando con timeout y captura stdout/stderr. None si falla/timeout.
+fn run_with_timeout(
+    args: &[&str],
+    timeout: Duration,
+    env_refs: &[(&str, &str)],
+) -> Option<std::process::Output> {
+    let mut child = Command::new(args[0])
+        .args(&args[1..])
+        .envs(env_refs.iter().map(|(k, v)| (*k, *v)))
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .ok()?;
+
+    let deadline = std::time::Instant::now() + timeout;
+    let status = loop {
+        match child.try_wait() {
+            Ok(Some(st)) => break st,
+            Ok(None) => {
+                if std::time::Instant::now() >= deadline {
+                    let _ = child.kill();
+                    let _ = child.wait();
+                    return None;
+                }
+                std::thread::sleep(Duration::from_millis(50));
+            }
+            Err(_) => return None,
+        }
+    };
+    let mut stdout = Vec::new();
+    let mut stderr = Vec::new();
+    if let Some(mut out) = child.stdout.take() {
+        let _ = std::io::Read::read_to_end(&mut out, &mut stdout);
+    }
+    if let Some(mut err) = child.stderr.take() {
+        let _ = std::io::Read::read_to_end(&mut err, &mut stderr);
+    }
+    let _ = child.wait();
+    Some(std::process::Output {
+        status,
+        stdout,
+        stderr,
+    })
+}
+
 impl WallpaperService {
     /// Ruta del wallpaper actual (settings.json wallpaper.path)
     pub fn current() -> String {
@@ -134,14 +179,16 @@ impl WallpaperService {
             .map(|(k, v)| (k.as_str(), v.as_str()))
             .collect();
 
-        // Backend 1: wrapper churros-apply-wallpaper
+        // Backend 1: wrapper churros-apply-wallpaper (con timeout: no bloquear
+        // la UI si el wrapper se cuelga).
         if which("churros-apply-wallpaper") {
-            let r = Command::new("churros-apply-wallpaper")
-                .arg(path)
-                .envs(env_refs.iter().map(|(k, v)| (*k, *v)))
-                .output();
+            let r = run_with_timeout(
+                &["churros-apply-wallpaper", path],
+                Duration::from_secs(10),
+                &env_refs,
+            );
             match r {
-                Ok(out) => {
+                Some(out) => {
                     println!(
                         "[wallpaper] wrapper stdout: {}",
                         String::from_utf8_lossy(&out.stdout)
@@ -157,7 +204,7 @@ impl WallpaperService {
                     }
                     println!("[wallpaper] wrapper fallo rc={:?}", out.status.code());
                 }
-                Err(e) => println!("[wallpaper] wrapper ex: {e}"),
+                None => println!("[wallpaper] wrapper timeout/ex"),
             }
         }
 

--- a/rust/preferences/src/services/wallpaper.rs
+++ b/rust/preferences/src/services/wallpaper.rs
@@ -115,7 +115,8 @@ impl WallpaperService {
     pub fn set(path: &str) -> bool {
         settings::set("wallpaper.path", serde_json::json!(path));
         let applied = Self::apply(path);
-        // TODO: hook pywal (services/pywal_service.py — regenerar paleta si está activo)
+        // Colores dinámicos: regenerar paleta pywal si está activo.
+        crate::services::pywal::PywalService::regenerate_if_enabled();
         applied
     }
 

--- a/rust/preferences/src/services/waybar.rs
+++ b/rust/preferences/src/services/waybar.rs
@@ -96,6 +96,64 @@ fn read_colors() -> Value {
     result
 }
 
+/// Lee style.css: font-family, font-size y background-alpha del bloque `*`
+/// (font-size/font-family/background-alpha se persisten en style.css, no en
+/// colors-waybar.css; leerlos de los colores los perdía siempre).
+fn read_style() -> Value {
+    let mut result = json!({});
+    if !style_path().exists() {
+        return result;
+    }
+    let Ok(content) = fs::read_to_string(style_path()) else {
+        return result;
+    };
+
+    let mut got_alpha = false;
+    for line in content.lines() {
+        let line = line.trim();
+        let Some((key, value)) = line.split_once(':') else {
+            continue;
+        };
+        let key = key.trim();
+        let value = value.trim().trim_end_matches(';').trim();
+
+        match key {
+            "font-family" => {
+                if result.get("font-family").is_none() {
+                    let v = value.trim_matches('\'');
+                    result["font-family"] = json!(v);
+                }
+            }
+            "font-size" => {
+                if result.get("font-size").is_none() {
+                    if let Some(px) = value.strip_suffix("px") {
+                        if let Ok(n) = px.trim().parse::<i64>() {
+                            result["font-size"] = json!(n);
+                        }
+                    }
+                }
+            }
+            "background-color" => {
+                // Solo el primer alpha(...): el del bloque `*`; el resto del
+                // archivo (tooltip, workspaces, mpris) usa alphas derivados.
+                if !got_alpha {
+                    if let Some(inner) = value.strip_prefix("alpha(") {
+                        let inner = inner.trim_end_matches(')');
+                        if let Some((_, a)) = inner.rsplit_once(',') {
+                            if let Ok(a) = a.trim().parse::<f64>() {
+                                result["background-alpha"] = json!(a);
+                                got_alpha = true;
+                            }
+                        }
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+    result
+}
+
 fn write_colors(values: &Value) {
     if let Some(parent) = colors_path().parent() {
         let _ = fs::create_dir_all(parent);
@@ -103,13 +161,17 @@ fn write_colors(values: &Value) {
     let bg = values.get("background").and_then(|v| v.as_str()).unwrap_or("#2a1612");
     let fg = values.get("foreground").and_then(|v| v.as_str()).unwrap_or("#c9c4c3");
     let accent = values.get("accent").and_then(|v| v.as_str()).unwrap_or("#DE8636");
-    let content = format!(
+    let content = colors_css(bg, fg, accent);
+    let _ = fs::write(colors_path(), content);
+}
+
+fn colors_css(bg: &str, fg: &str, accent: &str) -> String {
+    format!(
         "@define-color background {bg};\n\
          @define-color foreground {fg};\n\
          @define-color color4 {accent};\n\
          @define-color color1 {accent};\n"
-    );
-    let _ = fs::write(colors_path(), content);
+    )
 }
 
 fn write_style(values: &Value) {
@@ -402,10 +464,11 @@ impl WaybarService {
         defaults()
     }
 
-    /// Lee config.jsonc + colors-waybar.css y devuelve el estado completo.
+    /// Lee config.jsonc + colors-waybar.css + style.css y devuelve el estado completo.
     pub fn get() -> Value {
         let cfg = read_jsonc(&config_path()).unwrap_or_else(|| json!({}));
         let colors = read_colors();
+        let style = read_style();
 
         let d = defaults();
         json!({
@@ -413,12 +476,12 @@ impl WaybarService {
             "position": cfg.get("position").and_then(|v| v.as_str()).unwrap_or(d["position"].as_str().unwrap()).to_string(),
             "spacing": cfg.get("spacing").and_then(|v| v.as_i64()).unwrap_or(d["spacing"].as_i64().unwrap()),
             "height": cfg.get("height").and_then(|v| v.as_i64()).unwrap_or(d["height"].as_i64().unwrap()),
-            "font-size": colors.get("font-size").and_then(|v| v.as_i64()).unwrap_or(d["font-size"].as_i64().unwrap()),
-            "font-family": colors.get("font-family").and_then(|v| v.as_str()).unwrap_or(d["font-family"].as_str().unwrap()).to_string(),
+            "font-size": style.get("font-size").and_then(|v| v.as_i64()).unwrap_or(d["font-size"].as_i64().unwrap()),
+            "font-family": style.get("font-family").and_then(|v| v.as_str()).unwrap_or(d["font-family"].as_str().unwrap()).to_string(),
             "background": colors.get("background").and_then(|v| v.as_str()).unwrap_or(d["background"].as_str().unwrap()).to_string(),
             "foreground": colors.get("foreground").and_then(|v| v.as_str()).unwrap_or(d["foreground"].as_str().unwrap()).to_string(),
             "accent": colors.get("accent").and_then(|v| v.as_str()).unwrap_or(d["accent"].as_str().unwrap()).to_string(),
-            "background-alpha": colors.get("background-alpha").and_then(|v| v.as_f64()).unwrap_or(d["background-alpha"].as_f64().unwrap()),
+            "background-alpha": style.get("background-alpha").and_then(|v| v.as_f64()).unwrap_or(d["background-alpha"].as_f64().unwrap()),
             "modules-left": cfg.get("modules-left").cloned().unwrap_or_else(|| json!([])),
             "modules-center": cfg.get("modules-center").cloned().unwrap_or_else(|| json!([])),
             "modules-right": cfg.get("modules-right").cloned().unwrap_or_else(|| json!([])),
@@ -461,6 +524,24 @@ impl WaybarService {
         write_jsonc(&config_path(), &cfg);
         write_colors(values);
         write_style(values);
+    }
+
+    /// Aplica una paleta pywal a waybar (colors-waybar.css) y recarga.
+    /// Solo toca los colores, sin pisar config.jsonc/style.css.
+    pub fn apply_pywal_colors(bg: &str, fg: &str, accent: &str) {
+        if let Some(parent) = colors_path().parent() {
+            let _ = fs::create_dir_all(parent);
+        }
+        let _ = fs::write(colors_path(), colors_css(bg, fg, accent));
+
+        // Recargar waybar con SIGUSR2 (recarga la config en vivo)
+        let env = build_env();
+        let _ = Command::new("pkill")
+            .args(["-SIGUSR2", "waybar"])
+            .envs(env.iter().cloned())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status();
     }
 
     /// Mata waybar limpiamente y lo relanza (equivalente a reload()).

--- a/rust/preferences/src/services/window_rules_service.rs
+++ b/rust/preferences/src/services/window_rules_service.rs
@@ -124,30 +124,12 @@ fn serialize_rule(rule: &Value) -> String {
     lines.join("\n") + "\n"
 }
 
-/// Quita el comentario "// Window rules" final del prefijo
-/// (equivalente a re.sub(r"//+\s*Window rules\s*\n+\s*\Z", "", ...)).
-fn strip_window_rules_comment(prefix: &str) -> String {
-    let trimmed = prefix.trim_end();
-    const MARK: &str = "Window rules";
-
-    if let Some(pos) = trimmed.rfind(MARK) {
-        if pos + MARK.len() == trimmed.len() {
-            let before = &trimmed[..pos];
-            let before = before.trim_end();
-            if before.ends_with('/') {
-                let mut cut = before.len();
-                let bytes = before.as_bytes();
-                while cut > 0 && (bytes[cut - 1] == b'/' || bytes[cut - 1] == b' ' || bytes[cut - 1] == b'\t') {
-                    cut -= 1;
-                }
-                return before[..cut].trim_end().to_string();
-            }
-        }
-    }
-    prefix.to_string()
-}
-
 /// Reescribe todas las reglas (equivalente a _rewrite_all).
+///
+/// Reemplaza SOLO los bloques window-rule, conservando el contenido que haya
+/// entre ellos (comentarios, marcadores [CHURROS-GLASS-*], otros bloques).
+/// La versión anterior descartaba todo lo que hubiera entre el primer y el
+/// último bloque.
 fn rewrite_all(rules: &[Value]) {
     let content = read();
     let (blocks, lines) = find_all_blocks(&content, "window-rule");
@@ -155,26 +137,24 @@ fn rewrite_all(rules: &[Value]) {
         return;
     }
 
-    let first_start = blocks[0].0;
-    let last_end = blocks[blocks.len() - 1].1;
-
-    let mut prefix = lines[..first_start].join("\n");
-    if !prefix.is_empty() {
-        prefix = strip_window_rules_comment(&(prefix.trim_end().to_string() + "\n"));
+    let mut out: Vec<String> = Vec::new();
+    let mut cursor = 0usize;
+    for (i, (start, end)) in blocks.iter().enumerate() {
+        for l in &lines[cursor..*start] {
+            out.push(l.clone());
+        }
+        if let Some(rule) = rules.get(i) {
+            for l in serialize_rule(rule).lines() {
+                out.push(l.to_string());
+            }
+        }
+        cursor = end + 1;
     }
-    if prefix.is_empty() {
-        prefix = String::new();
+    for l in &lines[cursor..] {
+        out.push(l.clone());
     }
 
-    let suffix = lines[last_end + 1..].join("\n");
-
-    let mut body = String::new();
-    for r in rules {
-        body += &serialize_rule(r);
-    }
-
-    let new_content = format!("{prefix}\n// Window rules\n{body}{suffix}");
-    write_atomic(&new_content);
+    write_atomic(&(out.join("\n") + "\n"));
 }
 
 impl WindowRulesService {

--- a/rust/preferences/src/widgets/color_picker.rs
+++ b/rust/preferences/src/widgets/color_picker.rs
@@ -17,28 +17,43 @@ pub struct ColorPickerRow {
     callback: Rc<RefCell<Option<Box<dyn Fn(&str)>>>>,
 }
 
-fn hex_to_rgba(hex: &str, alpha: f64) -> (f64, f64, f64) {
+/// Parse "#rrggbb" (alpha externo) o "#rrggbbaa" (alpha propio).
+fn hex_to_rgba(hex: &str, alpha: f64) -> (f64, f64, f64, f64) {
     let hex = hex.trim_start_matches('#');
-    if hex.len() != 6 {
-        return (1.0, 1.0, 1.0);
+    match hex.len() {
+        6 => {
+            let r = u8::from_str_radix(&hex[0..2], 16).unwrap_or(255) as f64 / 255.0;
+            let g = u8::from_str_radix(&hex[2..4], 16).unwrap_or(255) as f64 / 255.0;
+            let b = u8::from_str_radix(&hex[4..6], 16).unwrap_or(255) as f64 / 255.0;
+            (r, g, b, alpha)
+        }
+        8 => {
+            let r = u8::from_str_radix(&hex[0..2], 16).unwrap_or(255) as f64 / 255.0;
+            let g = u8::from_str_radix(&hex[2..4], 16).unwrap_or(255) as f64 / 255.0;
+            let b = u8::from_str_radix(&hex[4..6], 16).unwrap_or(255) as f64 / 255.0;
+            let a = u8::from_str_radix(&hex[6..8], 16).unwrap_or(255) as f64 / 255.0;
+            (r, g, b, a)
+        }
+        _ => (1.0, 1.0, 1.0, alpha),
     }
-    let r = u8::from_str_radix(&hex[0..2], 16).unwrap_or(255) as f64 / 255.0;
-    let g = u8::from_str_radix(&hex[2..4], 16).unwrap_or(255) as f64 / 255.0;
-    let b = u8::from_str_radix(&hex[4..6], 16).unwrap_or(255) as f64 / 255.0;
-    let _ = alpha;
-    (r, g, b)
 }
 
-fn rgba_to_hex(r: f64, g: f64, b: f64) -> String {
+/// 6 dígitos si el alpha es total, 8 (con alpha) si no.
+fn rgba_to_hex(r: f64, g: f64, b: f64, a: f64) -> String {
     let r = (r * 255.0).round().clamp(0.0, 255.0) as u8;
     let g = (g * 255.0).round().clamp(0.0, 255.0) as u8;
     let b = (b * 255.0).round().clamp(0.0, 255.0) as u8;
-    format!("#{r:02x}{g:02x}{b:02x}")
+    if a >= 1.0 {
+        format!("#{r:02x}{g:02x}{b:02x}")
+    } else {
+        let a = (a * 255.0).round().clamp(0.0, 255.0) as u8;
+        format!("#{r:02x}{g:02x}{b:02x}{a:02x}")
+    }
 }
 
 fn is_valid_hex(text: &str) -> bool {
     let t = text.strip_prefix('#').unwrap_or(text);
-    t.len() == 6 && t.chars().all(|c| c.is_ascii_hexdigit())
+    (t.len() == 6 || t.len() == 8) && t.chars().all(|c| c.is_ascii_hexdigit())
 }
 
 impl ColorPickerRow {
@@ -86,8 +101,8 @@ impl ColorPickerRow {
 
         let entry = gtk::Entry::new();
         entry.set_text(value);
-        entry.set_width_chars(8);
-        entry.set_max_length(7);
+        entry.set_width_chars(9);
+        entry.set_max_length(9);
         entry.set_valign(gtk::Align::Center);
         entry.add_css_class("color-entry");
 
@@ -103,8 +118,8 @@ impl ColorPickerRow {
         // Swatch draw
         let color_for_draw = color.clone();
         swatch.set_draw_func(move |_area, cr, w, h| {
-            let (r, g, b) = hex_to_rgba(&color_for_draw.borrow(), 1.0);
-            cr.set_source_rgb(r, g, b);
+            let (r, g, b, a) = hex_to_rgba(&color_for_draw.borrow(), 1.0);
+            cr.set_source_rgba(r, g, b, a);
             cr.rectangle(0.0, 0.0, w as f64, h as f64);
             let _ = cr.fill();
         });
@@ -119,8 +134,7 @@ impl ColorPickerRow {
                 let window = btn.root().and_downcast::<gtk::Window>();
                 let dialog = gtk::ColorDialog::new();
                 dialog.set_title("Elegir color");
-
-                let (r, g, b) = hex_to_rgba(&color.borrow(), 1.0);
+                let (r, g, b, _a) = hex_to_rgba(&color.borrow(), 1.0);
                 let rgba = gdk_rgba(r, g, b);
 
                 let color2 = color.clone();
@@ -135,13 +149,12 @@ impl ColorPickerRow {
                         None::<&gio::Cancellable>,
                         move |result| match result {
                             Ok(picked) => {
-                                let (pr, pg, pb, _pa) = (
+                                let hex = rgba_to_hex(
                                     picked.red() as f64,
                                     picked.green() as f64,
                                     picked.blue() as f64,
-                                    picked.alpha(),
+                                    picked.alpha() as f64,
                                 );
-                                let hex = rgba_to_hex(pr, pg, pb);
                                 *color2.borrow_mut() = hex.clone();
                                 value_label2.set_label(&hex);
                                 swatch2.queue_draw();
@@ -171,7 +184,7 @@ impl ColorPickerRow {
                 } else {
                     format!("#{text}")
                 };
-                if t.len() != 7 {
+                if t.len() != 7 && t.len() != 9 {
                     return;
                 }
                 if !is_valid_hex(&t) {
@@ -196,7 +209,7 @@ impl ColorPickerRow {
                 } else {
                     format!("#{text}")
                 };
-                if t.len() != 7 || !is_valid_hex(&t) {
+                if (t.len() != 7 && t.len() != 9) || !is_valid_hex(&t) {
                     let current = color.borrow().clone();
                     entry.set_text(&current);
                     return;

--- a/rust/preferences/src/widgets/combo_row.rs
+++ b/rust/preferences/src/widgets/combo_row.rs
@@ -11,7 +11,7 @@ use std::rc::Rc;
 pub struct ComboRow {
     pub root: gtk::Box,
     pub combo: gtk::DropDown,
-    values: RefCell<Vec<String>>,
+    values: Rc<RefCell<Vec<String>>>,
     callback: Rc<RefCell<Option<Box<dyn Fn(&str)>>>>,
 }
 
@@ -54,8 +54,19 @@ impl ComboRow {
 
         root.append(&labels);
 
+        // Si el valor seleccionado no está en la lista, añadirlo al principio:
+        // así el combo nunca muestra un índice 0 erróneo y no se pisa el valor
+        // real del usuario al guardar.
+        let mut effective: Vec<&str> = values.to_vec();
+        if let Some(sel) = selected {
+            if !sel.is_empty() && !effective.contains(&sel) {
+                effective.insert(0, sel);
+            }
+        }
+        let values = effective;
+
         let model = gtk::StringList::new(&[]);
-        for v in values {
+        for v in &values {
             model.append(v);
         }
 
@@ -69,15 +80,16 @@ impl ComboRow {
 
         root.append(&combo);
 
-        let values_owned: Vec<String> = values.iter().map(|s| s.to_string()).collect();
+        let values_owned: Rc<RefCell<Vec<String>>> =
+            Rc::new(RefCell::new(values.iter().map(|s| s.to_string()).collect()));
         let callback_rc = Rc::new(RefCell::new(callback));
 
         if callback_rc.borrow().is_some() {
             let cb = Rc::clone(&callback_rc);
-            let values = values_owned.clone();
+            let values = Rc::clone(&values_owned);
             combo.connect_selected_notify(move |combo| {
                 let idx = combo.selected() as usize;
-                if let Some(value) = values.get(idx) {
+                if let Some(value) = values.borrow().get(idx) {
                     if let Some(cb) = cb.borrow().as_ref() {
                         cb(value);
                     }
@@ -88,7 +100,7 @@ impl ComboRow {
         Self {
             root,
             combo,
-            values: RefCell::new(values_owned),
+            values: values_owned,
             callback: callback_rc,
         }
     }
@@ -108,12 +120,13 @@ impl ComboRow {
             model.append(v);
         }
         self.combo.set_model(Some(&model));
+        // El callback lee `self.values` compartido, así que actualizarlo aquí
+        // lo mantiene sincronizado (antes usaba una copia obsoleta).
         *self.values.borrow_mut() = values.iter().map(|s| s.to_string()).collect();
-        if let Some(sel) = selected {
-            if let Some(idx) = self.values.borrow().iter().position(|v| v == sel) {
-                self.combo.set_selected(idx as u32);
-            }
-        }
+        let idx = selected
+            .and_then(|sel| self.values.borrow().iter().position(|v| v == sel))
+            .unwrap_or(0);
+        self.combo.set_selected(idx as u32);
     }
 }
 

--- a/rust/preferences/src/widgets/sidebar.rs
+++ b/rust/preferences/src/widgets/sidebar.rs
@@ -155,7 +155,10 @@ impl Sidebar {
         }
     }
 
-    fn on_search(&self, query: &str) {
+    /// Filtra el menú y muestra el popover de resultados.
+    /// Público porque el wiring se hace desde window.rs (Sidebar no puede
+    /// auto-referenciarse para conectar su propio Search).
+    pub fn on_search(&self, query: &str) {
         let query = query.to_lowercase();
 
         // Filtrar botones del menú principal

--- a/rust/preferences/src/window.rs
+++ b/rust/preferences/src/window.rs
@@ -329,27 +329,18 @@ impl PreferencesWindow {
         let is_narrow = Rc::clone(&self.is_narrow);
         let threshold = self.narrow_threshold;
 
-        // Check cada 250ms mientras la ventana está mapeada
+        // connect_realize (una sola vez) en vez de connect_map: el map podía
+        // dispararse varias veces y acumular timers de 250ms concurrentes.
         let map_window = window.clone();
-        map_window.connect_map(move |_| {
+        map_window.connect_realize(move |_| {
+            apply_narrow(&window, &is_narrow, &sidebar_revealer, &toggle_button, threshold);
+
             let w = window.clone();
             let is_narrow = is_narrow.clone();
             let sidebar_revealer = sidebar_revealer.clone();
             let toggle_button = toggle_button.clone();
             glib::timeout_add_local(std::time::Duration::from_millis(250), move || {
-                let width = w.width();
-                let new_narrow = width < threshold;
-
-                if *is_narrow.borrow() != new_narrow {
-                    *is_narrow.borrow_mut() = new_narrow;
-                    if new_narrow {
-                        sidebar_revealer.set_reveal_child(false);
-                        toggle_button.set_visible(true);
-                    } else {
-                        sidebar_revealer.set_reveal_child(true);
-                        toggle_button.set_visible(false);
-                    }
-                }
+                apply_narrow(&w, &is_narrow, &sidebar_revealer, &toggle_button, threshold);
                 glib::ControlFlow::Continue
             });
         });
@@ -366,6 +357,22 @@ impl PreferencesWindow {
 impl PreferencesWindow {
     pub fn present(&self) {
         self.window.present();
+    }
+}
+
+/// Aplica el estado "narrow" de la ventana (oculta/muestra sidebar).
+fn apply_narrow(
+    window: &gtk::ApplicationWindow,
+    is_narrow: &Rc<RefCell<bool>>,
+    sidebar_revealer: &gtk::Revealer,
+    toggle_button: &gtk::Button,
+    threshold: i32,
+) {
+    let new_narrow = window.width() < threshold;
+    if *is_narrow.borrow() != new_narrow {
+        *is_narrow.borrow_mut() = new_narrow;
+        sidebar_revealer.set_reveal_child(!new_narrow);
+        toggle_button.set_visible(new_narrow);
     }
 }
 

--- a/rust/preferences/src/window.rs
+++ b/rust/preferences/src/window.rs
@@ -22,6 +22,9 @@ pub struct PreferencesWindow {
     history: Rc<RefCell<Vec<String>>>,
     narrow_threshold: i32,
     is_narrow: Rc<RefCell<bool>>,
+    // Mantener la referencia viva: si se dropea, GLib destruye el objeto y
+    // el handler de color-scheme deja de disparar.
+    gtk_settings: Option<gio::Settings>,
 }
 
 impl PreferencesWindow {
@@ -41,16 +44,23 @@ impl PreferencesWindow {
         window.set_resizable(true);
 
         let w = window.clone();
-        if let Some(schema_source) = gio::SettingsSchemaSource::default() {
-            if let Some(schema) = schema_source.lookup("org.gnome.desktop.interface", false) {
-                let settings =
-                    gio::Settings::new_full(&schema, None::<&gio::SettingsBackend>, None::<&str>);
-                settings.connect_changed(Some("color-scheme"), move |_, _| {
-                    let w = w.clone();
-                    glib::idle_add_local_once(move || refresh_theme(&w));
-                });
-            }
-        }
+        let gtk_settings = gio::SettingsSchemaSource::default().and_then(|schema_source| {
+            let schema = schema_source.lookup("org.gnome.desktop.interface", false)?;
+            let settings =
+                gio::Settings::new_full(&schema, None::<&gio::SettingsBackend>, None::<&str>);
+            settings.connect_changed(Some("color-scheme"), move |_, _| {
+                let w = w.clone();
+                glib::idle_add_local_once(move || refresh_theme(&w));
+            });
+            Some(settings)
+        });
+
+        // Hook en vivo: ThemeService::set notifica aquí directamente, sin
+        // depender de gsettings/dconf (equivalente a _refresh_root_theme del
+        // Python). El listener de color-scheme de arriba queda como refuerzo
+        // para cambios externos.
+        let theme_window = window.clone();
+        ThemeService::on_change(move |_dark| refresh_theme(&theme_window));
 
         // Layout principal
         let root = gtk::Box::new(gtk::Orientation::Horizontal, 0);
@@ -63,6 +73,16 @@ impl PreferencesWindow {
         sidebar_revealer.set_reveal_child(true);
         sidebar_revealer.set_child(Some(&sidebar.borrow().root));
         root.append(&sidebar_revealer);
+
+        // Cablear el buscador de la sidebar (el Search no puede conectar su
+        // propio callback porque necesitaría una referencia a su Sidebar).
+        let search_sidebar = Rc::clone(&sidebar);
+        sidebar.borrow().search.connect_search(move |query| {
+            let Ok(sidebar) = search_sidebar.try_borrow() else {
+                return;
+            };
+            sidebar.on_search(query);
+        });
 
         // Navegador con botón de toggle para modo estrecho
         let nav_box = gtk::Box::new(gtk::Orientation::Vertical, 0);
@@ -98,6 +118,7 @@ impl PreferencesWindow {
             history,
             narrow_threshold: 760,
             is_narrow,
+            gtk_settings,
         };
 
         win.register_pages();
@@ -361,6 +382,12 @@ fn apply_theme_class(window: &gtk::ApplicationWindow) {
 
 fn refresh_theme(window: &gtk::ApplicationWindow) {
     apply_theme_class(window);
+    // Flip del tema de los widgets GTK en vivo (Adwaita dark/light). Esto es
+    // lo que hace que botones/switch/entrys cambien al instante, además de
+    // los tokens CSS de window.light.
+    if let Some(settings) = gtk::Settings::default() {
+        settings.set_gtk_application_prefer_dark_theme(!ThemeService::is_dark());
+    }
     window.queue_draw();
     window.queue_resize();
 }

--- a/scripts/cli/check.sh
+++ b/scripts/cli/check.sh
@@ -366,13 +366,20 @@ elif [ "${#LOCAL_AUR[@]}" -eq 0 ]; then
     fail "no build_aur calls found in scripts/build-aur.sh"
 else
     aur_ok=1
+    aur_checked=0
     for pkg in "${LOCAL_AUR[@]}"; do
+        # Si ya está en la lista base (packages.x86_64) se instala por defecto,
+        # así que no necesita aparecer en netinstall.
+        if printf '%s\n' "${PACKAGES[@]}" | grep -qx "$pkg"; then
+            continue
+        fi
+        aur_checked=$((aur_checked + 1))
         if ! grep -qE "^[[:space:]]+- name:[[:space:]]+${pkg}[[:space:]]*$" "$NETINSTALL"; then
             fail "'$pkg' is built by build-aur.sh but missing from netinstall.yaml"
             aur_ok=0
         fi
     done
-    [ "$aur_ok" -eq 1 ] && pass "${#LOCAL_AUR[@]} local AUR packages listed in netinstall"
+    [ "$aur_ok" -eq 1 ] && pass "${aur_checked} local AUR packages listed in netinstall"
 fi
 
 # ------------------------------------------------------- Live overlay size


### PR DESCRIPTION
## Resumen

- **Blur centralizado** en window-rules de niri con marcadores `[CHURROS-GLASS-*]`; el modo rendimiento ahora desactiva el blur de verdad y `reload()` usa `niri msg action load-config-file` (antes `pkill -HUP niri` reiniciaba toda la sesión).
- **Tema claro/oscuro en vivo**: hook in-process (`ThemeService::on_change`) + `set_gtk_application_prefer_dark_theme` + gsettings `color-scheme`.
- **Transparencia de las apps**: alpha más bajo en CSS y sin `backdrop-filter` (no existe en GTK4); el blur lo pone niri.
- **Keyboard**: `split_quote` perdía la primera letra de cada comando; diálogos de añadir/editar atajo portados; escaping de comillas y bloque `binds`.
- Otros fixes: cursor corrompía `config.kdl`, parser wpctl con caracteres de árbol, tap-to-click esquema erróneo, autologin con pkexec, `color_picker` hex de 8 dígitos, `settings.json` no-objeto ya no paniquea, display paréntesis/VRR, lock_screen `--indicator` + quoting para sh, waybar `get()`, buscador de la sidebar muerto, switch on/off del mismo tamaño.
- **pywal: port PARCIAL** (`PywalService`) — regenera paleta y la aplica a `accent.css` + waybar; faltan foot/fuzzel/mako y la integración completa.

## Verificación

- `./churros check` pasa.
- Workspace compila.
- 8 tests unitarios (incluido roundtrip de toggle contra el `config.kdl` real y el roundtrip de escritura de keyboard).