### PR TITLE
fix: la app de ajustes no debe cerrarse al cambiar claro/oscuro

### DIFF
--- a/rust/preferences/src/main.rs
+++ b/rust/preferences/src/main.rs
@@ -14,6 +14,7 @@ use gtk::prelude::*;
 use gtk::gdk;
 
 use services::accent::AccentService;
+use services::theme::ThemeService;
 use window::PreferencesWindow;
 
 const APP_ID: &str = "org.churros.preferences";
@@ -82,10 +83,14 @@ fn activate(app: &gtk::Application) {
     logging::log("window creada");
     win.present();
     logging::log("presentada");
+    // PreferencesWindow guarda gio::Settings (color-scheme). Si se dropea
+    // al salir de activate, el handler muere aunque la ventana GTK siga.
+    std::mem::forget(win);
 }
 
 fn main() -> glib::ExitCode {
     logging::init("settings");
+    ThemeService::migrate_before_gtk();
 
     let app = gtk::Application::builder()
         .application_id(APP_ID)

--- a/rust/preferences/src/services/theme.rs
+++ b/rust/preferences/src/services/theme.rs
@@ -3,21 +3,21 @@
 // (equivalente a services/theme.py)
 // ==========================================
 
-use std::cell::RefCell;
+use std::cell::{Cell, RefCell};
 use std::fs;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::Command;
 
 use serde_json::json;
 
 use crate::services::settings;
 
-// Listeners de cambio de tema (dark/light). El patrón es el mismo que
-// Search::connect_search: los registra la ventana y ThemeService::set los
-// invoca al final para refrescar el tema en vivo sin depender de gsettings/
-// dconf/DBus. Todo corre en el hilo principal de GTK.
+// Listeners de cambio de tema (dark/light). Los registra la ventana y
+// ThemeService::set los invoca para refrescar la clase CSS y GtkSettings
+// sin depender de gsettings/dconf. Todo corre en el hilo principal de GTK.
 thread_local! {
     static THEME_LISTENERS: RefCell<Vec<Box<dyn Fn(bool)>>> = RefCell::new(Vec::new());
+    static APPLYING: Cell<bool> = const { Cell::new(false) };
 }
 
 fn cache_dir() -> PathBuf {
@@ -29,10 +29,15 @@ fn dark_flag() -> PathBuf {
     cache_dir().join("dark-flag")
 }
 
+fn gtk_ini(dir: &str) -> PathBuf {
+    let home = std::env::var("HOME").unwrap_or_else(|_| "/root".to_string());
+    PathBuf::from(home).join(".config").join(dir).join("settings.ini")
+}
+
 fn build_env() -> Vec<(String, String)> {
     let mut env: Vec<(String, String)> = std::env::vars().collect();
     if env.iter().all(|(k, _)| k != "WAYLAND_DISPLAY") {
-        let uid = unsafe { libc_getuid() };
+        let uid = libc_getuid();
         let xrd = format!("/run/user/{uid}");
         if std::path::Path::new(&xrd).is_dir() {
             if let Ok(entries) = fs::read_dir(&xrd) {
@@ -47,18 +52,13 @@ fn build_env() -> Vec<(String, String)> {
         }
     }
     if env.iter().all(|(k, _)| k != "XDG_RUNTIME_DIR") {
-        let uid = unsafe { libc_getuid() };
+        let uid = libc_getuid();
         env.push(("XDG_RUNTIME_DIR".to_string(), format!("/run/user/{uid}")));
     }
     env
 }
 
-// getuid sin dependencia libc: leer /proc/self/status o usar el uid del
-// propietario del proceso via /proc/self (mejor: std no expone uid).
-// Se usa el crate libc indirectamente a través de glib? No — lo resolvemos
-// leyendo /proc/self/loginuid o simplemente el uid del archivo /proc/self.
 fn libc_getuid() -> u32 {
-    // Lectura de /proc/self/status línea Uid:
     if let Ok(content) = fs::read_to_string("/proc/self/status") {
         for line in content.lines() {
             if let Some(rest) = line.strip_prefix("Uid:") {
@@ -73,10 +73,8 @@ fn libc_getuid() -> u32 {
     1000
 }
 
-/// Actualiza SOLO las claves de tema en el ini, preservando el resto
-/// (cursor, fuente, etc.). El Python sobrescribía el archivo entero y
-/// perdía las claves que escriben otras páginas (p. ej. cursor.rs).
-fn update_ini_key(ini: &PathBuf, key: &str, value: &str) {
+/// Actualiza una clave del ini preservando el resto (cursor, fuente, …).
+fn update_ini_key(ini: &Path, key: &str, value: &str) {
     if let Some(parent) = ini.parent() {
         let _ = fs::create_dir_all(parent);
     }
@@ -103,53 +101,93 @@ fn update_ini_key(ini: &PathBuf, key: &str, value: &str) {
     let _ = fs::write(ini, content + "\n");
 }
 
-fn write_gtk_settings(dark: bool) {
-    let home = std::env::var("HOME").unwrap_or_else(|_| "/root".to_string());
-    let icon_theme = settings::get_string("icons.theme", if dark { "Papirus-Dark" } else { "Papirus" });
-    let gtk_theme = if dark { "Adwaita-dark" } else { "Adwaita" };
-
-    for dir in ["gtk-3.0", "gtk-4.0"] {
-        let ini = PathBuf::from(&home).join(".config").join(dir).join("settings.ini");
-        update_ini_key(&ini, "gtk-theme-name", gtk_theme);
-        update_ini_key(
-            &ini,
-            "gtk-application-prefer-dark-theme",
-            if dark { "1" } else { "0" },
-        );
-        update_ini_key(&ini, "gtk-icon-theme-name", &icon_theme);
+fn migrate_adwaita_dark_ini(ini: &Path) {
+    let Ok(content) = fs::read_to_string(ini) else {
+        return;
+    };
+    if !content
+        .lines()
+        .any(|line| line.trim() == "gtk-theme-name=Adwaita-dark")
+    {
+        return;
     }
+    let updated = content.replace("gtk-theme-name=Adwaita-dark", "gtk-theme-name=Adwaita");
+    let _ = fs::write(ini, updated);
+}
 
-    // Mecanismo en vivo de GTK4: color-scheme via gsettings (el portal de
-    // settings lo propaga y el listener de window.rs refresca la clase CSS
-    // "light" sin reiniciar la app). El gtk-theme-name de settings.ini solo
-    // aplica al arrancar; cambiarlo en caliente puede re-tematizar a medias.
-    let _ = Command::new("gsettings")
-        .args([
-            "set",
-            "org.gnome.desktop.interface",
-            "color-scheme",
-            if dark { "prefer-dark" } else { "default" },
-        ])
-        .output();
-    let _ = Command::new("gsettings")
-        .args([
-            "set",
-            "org.gnome.desktop.interface",
-            "gtk-theme",
-            gtk_theme,
-        ])
-        .output();
-
-    // Flag en caché para que is_dark() sea rápido sin leer settings.json
+fn write_dark_flag(dark: bool) {
     if let Some(parent) = dark_flag().parent() {
         let _ = fs::create_dir_all(parent);
     }
     let _ = fs::write(dark_flag(), if dark { "1" } else { "0" });
 }
 
+/// Persistencia para otras apps. No toca gtk-theme-name en GTK4: Adwaita-dark
+/// no existe como tema GTK4 (Adwaita va integrado) y cambiar gtk-theme en
+/// caliente recarga el CSS de esta misma app y la termina cerrando.
+fn persist_desktop(dark: bool) {
+    update_ini_key(
+        &gtk_ini("gtk-3.0"),
+        "gtk-application-prefer-dark-theme",
+        if dark { "1" } else { "0" },
+    );
+    update_ini_key(&gtk_ini("gtk-3.0"), "gtk-theme-name", "Adwaita");
+    update_ini_key(
+        &gtk_ini("gtk-4.0"),
+        "gtk-application-prefer-dark-theme",
+        if dark { "1" } else { "0" },
+    );
+
+    let _ = Command::new("gsettings")
+        .args([
+            "set",
+            "org.gnome.desktop.interface",
+            "color-scheme",
+            if dark { "prefer-dark" } else { "prefer-light" },
+        ])
+        .output();
+
+    let env = build_env();
+    let env_refs: Vec<(&str, &str)> = env
+        .iter()
+        .map(|(k, v)| (k.as_str(), v.as_str()))
+        .collect();
+    let _ = Command::new("pkill")
+        .args(["-SIGUSR2", "waybar"])
+        .envs(env_refs.iter().map(|(k, v)| (*k, *v)))
+        .output();
+    let _ = Command::new("pkill")
+        .args([if dark { "-SIGUSR1" } else { "-SIGUSR2" }, "foot"])
+        .envs(env_refs.iter().map(|(k, v)| (*k, *v)))
+        .output();
+
+    if crate::services::pywal::PywalService::enabled() {
+        let _ = crate::services::pywal::PywalService::regenerate_if_enabled();
+    }
+}
+
 pub struct ThemeService;
 
 impl ThemeService {
+    /// Corregir leftovers de Adwaita-dark *antes* de gtk_init. En runtime
+    /// cambiar gtk-theme-name recarga el stylesheet y GTK4 se cae.
+    pub fn migrate_before_gtk() {
+        migrate_adwaita_dark_ini(&gtk_ini("gtk-3.0"));
+        migrate_adwaita_dark_ini(&gtk_ini("gtk-4.0"));
+
+        let output = Command::new("gsettings")
+            .args(["get", "org.gnome.desktop.interface", "gtk-theme"])
+            .output();
+        if let Ok(output) = output {
+            let value = String::from_utf8_lossy(&output.stdout);
+            if value.contains("Adwaita-dark") {
+                let _ = Command::new("gsettings")
+                    .args(["set", "org.gnome.desktop.interface", "gtk-theme", "Adwaita"])
+                    .output();
+            }
+        }
+    }
+
     pub fn is_dark() -> bool {
         if let Ok(content) = fs::read_to_string(dark_flag()) {
             return content.trim() == "1";
@@ -161,36 +199,24 @@ impl ThemeService {
     }
 
     pub fn set(dark: bool) {
-        settings::set("theme.dark", json!(dark));
-        write_gtk_settings(dark);
-
-        let env = build_env();
-
-        // waybar: SIGUSR2 recarga; foot: SIGUSR1 dark, SIGUSR2 light
-        let env_refs: Vec<(&str, &str)> = env
-            .iter()
-            .map(|(k, v)| (k.as_str(), v.as_str()))
-            .collect();
-        let _ = Command::new("pkill")
-            .args(["-SIGUSR2", "waybar"])
-            .envs(env_refs.iter().map(|(k, v)| (*k, *v)))
-            .output();
-        let _ = Command::new("pkill")
-            .args([if dark { "-SIGUSR1" } else { "-SIGUSR2" }, "foot"])
-            .envs(env_refs.iter().map(|(k, v)| (*k, *v)))
-            .output();
-
-        // TODO: pywal integration (services/pywal_service.py)
-
-        // Colores dinámicos: regenerar paleta si pywal está activo (paridad
-        // con theme.py del Python).
-        if crate::services::pywal::PywalService::enabled() {
-            let _ = crate::services::pywal::PywalService::regenerate_if_enabled();
+        if APPLYING.with(Cell::get) {
+            return;
         }
+        if Self::is_dark() == dark {
+            return;
+        }
+        APPLYING.with(|flag| flag.set(true));
 
-        // Notificar en vivo a la ventana (refresh_theme) sin round-trip
-        // externo: mismo hook que _refresh_root_theme() del Python.
+        settings::set("theme.dark", json!(dark));
+        write_dark_flag(dark);
+        crate::logging::log(&format!("theme set dark={dark}"));
+
+        // En vivo en ESTE proceso: clase CSS + prefer-dark. No tocar
+        // gtk-theme-name ni gsettings gtk-theme (eso cierra la ventana).
         Self::notify(dark);
+
+        glib::idle_add_local_once(move || persist_desktop(dark));
+        APPLYING.with(|flag| flag.set(false));
     }
 
     /// Registra un callback que se invoca en cada cambio de tema.
@@ -229,5 +255,20 @@ mod tests {
         ThemeService::notify(false);
 
         assert_eq!(*received.borrow(), vec![true, true, false, false]);
+    }
+
+    #[test]
+    fn migrate_rewrites_adwaita_dark() {
+        let dir = std::env::temp_dir().join(format!("churros-theme-test-{}", std::process::id()));
+        let _ = fs::create_dir_all(&dir);
+        let ini = dir.join("settings.ini");
+        fs::write(&ini, "[Settings]\ngtk-theme-name=Adwaita-dark\ngtk-font-name=Inter 11\n")
+            .unwrap();
+        migrate_adwaita_dark_ini(&ini);
+        let content = fs::read_to_string(&ini).unwrap();
+        assert!(content.contains("gtk-theme-name=Adwaita\n"));
+        assert!(!content.contains("Adwaita-dark"));
+        assert!(content.contains("gtk-font-name=Inter 11"));
+        let _ = fs::remove_dir_all(dir);
     }
 }

--- a/rust/preferences/src/widgets/switch_row.rs
+++ b/rust/preferences/src/widgets/switch_row.rs
@@ -23,6 +23,11 @@ impl SwitchRow {
         let switch = gtk::Switch::new();
         switch.set_active(active);
         switch.set_valign(gtk::Align::Center);
+        // El Switch vive dentro de un GtkButton (la fila). Si el Switch
+        // también recibe el clic, GTK dispara notify::active y luego el
+        // clicked de la fila vuelve a togglear: dos ThemeService::set en
+        // el mismo evento, con gtk-theme a medias, y la app se cierra.
+        switch.set_can_target(false);
 
         let row = Row::new(
             title,

--- a/rust/preferences/src/window.rs
+++ b/rust/preferences/src/window.rs
@@ -24,6 +24,7 @@ pub struct PreferencesWindow {
     is_narrow: Rc<RefCell<bool>>,
     // Mantener la referencia viva: si se dropea, GLib destruye el objeto y
     // el handler de color-scheme deja de disparar.
+    #[allow(dead_code)]
     gtk_settings: Option<gio::Settings>,
 }
 
@@ -393,8 +394,7 @@ fn refresh_theme(window: &gtk::ApplicationWindow) {
     // lo que hace que botones/switch/entrys cambien al instante, además de
     // los tokens CSS de window.light.
     if let Some(settings) = gtk::Settings::default() {
-        settings.set_gtk_application_prefer_dark_theme(!ThemeService::is_dark());
+        settings.set_gtk_application_prefer_dark_theme(ThemeService::is_dark());
     }
     window.queue_draw();
-    window.queue_resize();
 }


### PR DESCRIPTION
Al conmutar claro/oscuro se publicaba `gtk-theme=Adwaita-dark`. Ese tema no existe en GTK4 y recargar el stylesheet en caliente cierra la ventana. El switch de la fila disparaba el cambio dos veces en el mismo clic.

El modo oscuro pasa a `color-scheme` y `prefer-dark-theme`, sin cambiar `gtk-theme-name` en runtime.