### PR TITLE
fix: centralizar la versión de la distro en el archivo VERSION

### DIFF
--- a/branding/customize_airootfs.sh
+++ b/branding/customize_airootfs.sh
@@ -16,6 +16,12 @@ cp /root/branding/files/os-release /usr/lib/os-release
 cp /root/branding/files/issue /etc/issue
 cp /root/branding/files/motd /etc/motd
 
+if [ -f /root/branding/VERSION ] && [ -f /root/branding/stamp-os-release.sh ]; then
+    ver=$(tr -d '[:space:]' < /root/branding/VERSION)
+    bash /root/branding/stamp-os-release.sh /etc/os-release "$ver"
+    bash /root/branding/stamp-os-release.sh /usr/lib/os-release "$ver"
+fi
+
 chmod 644 /etc/os-release
 chmod 644 /usr/lib/os-release
 chmod 644 /etc/issue

--- a/branding/stamp-os-release.sh
+++ b/branding/stamp-os-release.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+#
+# Write VERSION_ID, VERSION and PRETTY_NAME into an os-release file.
+# Usage: stamp-os-release.sh <os-release-path> <version>
+set -euo pipefail
+
+file=${1:-}
+ver=${2:-}
+
+if [ ! -f "$file" ]; then
+    echo "stamp-os-release: file not found: $file" >&2
+    exit 1
+fi
+
+if [[ ! "$ver" =~ ^[0-9]+(\.[0-9]+)*$ ]]; then
+    echo "stamp-os-release: invalid version: $ver" >&2
+    exit 1
+fi
+
+set_or_insert() {
+    local key=$1
+    local value=$2
+    local after=$3
+    if grep -q "^${key}=" "$file"; then
+        sed -i "s|^${key}=.*|${key}=${value}|" "$file"
+    else
+        sed -i "/^${after}=/a ${key}=${value}" "$file"
+    fi
+}
+
+set_or_insert VERSION_ID "$ver" ID
+set_or_insert VERSION "\"${ver}\"" VERSION_ID
+set_or_insert PRETTY_NAME "\"ChurrOS ${ver}\"" NAME

--- a/docs/apps.md
+++ b/docs/apps.md
@@ -34,7 +34,7 @@ Pantalla de bienvenida al iniciar la sesión Live.
 - Dar la bienvenida al usuario.
 - Ofrecer accesos a instalación, GitHub y comunidad.
 
-`system_card.rs` y `system_info.rs` existen (leen `/proc` y `/etc/os-release`) pero la `SystemCard` **no se monta** en la ventana actual. El footer muestra `Linux • Niri • ChurrOS` (versión embebida en el crate; hoy no lee `VERSION` del repo).
+`system_card.rs` y `system_info.rs` existen (leen `/proc` y `/etc/os-release`) pero la `SystemCard` **no se monta** en la ventana actual. El footer muestra `Linux • Niri • ChurrOS` más la versión de `churros_services::version::distro()` (archivo `VERSION` del repo, embebido al compilar).
 
 ## Stack
 
@@ -189,7 +189,6 @@ cargo build --release --manifest-path rust/Cargo.toml
 # Future Work
 
 - Empaquetar las apps como paquetes pacman propios.
-- Leer `VERSION` del repo en el footer de welcome (hoy está embebida en el crate).
 - Completar i18n (los `.po` existen; las apps Rust aún no cargan gettext).
 - churros-ui: widgets y CSS compartidos.
 - Tests automatizados de las apps GTK.

--- a/docs/branding.md
+++ b/docs/branding.md
@@ -134,7 +134,7 @@ Programas como:
 
 obtienen información desde este archivo.
 
-Debe contener la identidad oficial de ChurrOS.
+Debe contener la identidad oficial de ChurrOS. El archivo en git deja `PRETTY_NAME` en rolling; `./churros build` y `customize_airootfs.sh` escriben `VERSION_ID`, `VERSION` y `PRETTY_NAME` a partir del `VERSION` del repo.
 
 ---
 

--- a/docs/release.md
+++ b/docs/release.md
@@ -111,7 +111,7 @@ Verifica:
 
 # 5. Actualizar la versión
 
-El número de versión vive en `VERSION` (lo muestran `./churros version` y `./churros info`). Debe coincidir con el tag de GitHub.
+El número de versión vive en `VERSION`. Lo muestran `./churros version`, `./churros info`, el footer de welcome, Ajustes y el `os-release` de la ISO. Debe coincidir con el tag de GitHub.
 
 La versión actual es **0.6** (tag `v0.6`). El esquema previsto es Semantic Versioning (`MAJOR.MINOR.PATCH`); algunos tags históricos omiten el parche (`v0.6`).
 

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -110,6 +110,7 @@ dependencies = [
 name = "churros-welcome"
 version = "0.1.0"
 dependencies = [
+ "churros-services",
  "gio",
  "glib",
  "gtk4",

--- a/rust/churros-welcome/Cargo.toml
+++ b/rust/churros-welcome/Cargo.toml
@@ -9,6 +9,7 @@ deploy = true
 
 [dependencies]
 adw = { version = "0.9.2", package = "libadwaita" }
+churros-services = { path = "../services" }
 gio = "0.22.8"
 glib = "0.22.8"
 gtk = { version = "0.11.4", package = "gtk4", features = ["v4_22"] }

--- a/rust/churros-welcome/src/footer.rs
+++ b/rust/churros-welcome/src/footer.rs
@@ -1,9 +1,10 @@
 use gtk::prelude::*;
 
-const VERSION: &str = "0.2.0";
-
 pub fn build() -> gtk::Label {
-    let footer = gtk::Label::new(Some(&format!("Linux • Niri • ChurrOS {VERSION}")));
+    let footer = gtk::Label::new(Some(&format!(
+        "Linux • Niri • ChurrOS {}",
+        churros_services::version::distro()
+    )));
 
     footer.add_css_class("footer");
     footer.set_halign(gtk::Align::Center);

--- a/rust/preferences/src/pages/system.rs
+++ b/rust/preferences/src/pages/system.rs
@@ -19,11 +19,12 @@ pub fn build(navigator: gtk::Stack) -> Page {
     // Información
     let mut information = Group::new("Información");
 
+    let version_label = format!("ChurrOS {}", SystemService::version());
     information.add(&Row::new(
         "Versión",
         None,
         Some("system.svg"),
-        Some("ChurrOS Beta"),
+        Some(&version_label),
         None,
         None,
     ));

--- a/rust/preferences/src/services/about.rs
+++ b/rust/preferences/src/services/about.rs
@@ -10,7 +10,7 @@ impl AboutService {
     }
 
     pub fn version() -> &'static str {
-        "Beta"
+        churros_services::version::distro()
     }
 
     pub fn edition() -> &'static str {

--- a/rust/preferences/src/services/system.rs
+++ b/rust/preferences/src/services/system.rs
@@ -12,7 +12,7 @@ impl SystemService {
     }
 
     pub fn version() -> &'static str {
-        "Beta"
+        churros_services::version::distro()
     }
 
     pub fn edition() -> &'static str {

--- a/rust/services/src/lib.rs
+++ b/rust/services/src/lib.rs
@@ -10,6 +10,7 @@ pub mod brightness;
 pub mod ethernet;
 pub mod jsonc;
 pub mod power;
+pub mod version;
 pub mod waybar_style;
 pub mod wifi;
 

--- a/rust/services/src/version.rs
+++ b/rust/services/src/version.rs
@@ -1,0 +1,55 @@
+// Distro version from the repo-root `VERSION` file (compile-time).
+
+/// Product version baked into every crate that depends on `churros-services`.
+///
+/// The string is the contents of `VERSION` at the repository root, trimmed.
+/// Changing that file and rebuilding the ISO is enough to update welcome,
+/// Settings, and any other caller.
+pub fn distro() -> &'static str {
+    include_str!("../../../VERSION").trim()
+}
+
+/// `VERSION_ID` from `/etc/os-release`, falling back to [`distro`].
+///
+/// The ISO build stamps `VERSION_ID` into os-release so fastfetch and the
+/// installed system can read the same number without going through Rust.
+pub fn from_os_release() -> String {
+    if let Ok(content) = std::fs::read_to_string("/etc/os-release") {
+        for line in content.lines() {
+            let Some(rest) = line.strip_prefix("VERSION_ID=") else {
+                continue;
+            };
+            let value = rest.trim().trim_matches('"');
+            if !value.is_empty() {
+                return value.to_string();
+            }
+        }
+    }
+    distro().to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn distro_matches_version_file_on_disk() {
+        let path = concat!(env!("CARGO_MANIFEST_DIR"), "/../../VERSION");
+        let on_disk = std::fs::read_to_string(path)
+            .unwrap_or_else(|err| panic!("no se pudo leer {path}: {err}"));
+        let expected = on_disk.trim();
+        assert!(!expected.is_empty(), "VERSION no puede estar vacío");
+        assert!(
+            expected
+                .chars()
+                .all(|c| c.is_ascii_digit() || c == '.'),
+            "VERSION debe ser numérico con puntos, llegó {expected:?}"
+        );
+        assert_eq!(distro(), expected);
+    }
+
+    #[test]
+    fn from_os_release_never_empty() {
+        assert!(!from_os_release().is_empty());
+    }
+}

--- a/scripts/cli/build.sh
+++ b/scripts/cli/build.sh
@@ -45,6 +45,14 @@ mkdir -p archiso/airootfs/root/branding
 cp -r branding/files \
     archiso/airootfs/root/branding/
 
+cp VERSION archiso/airootfs/root/branding/VERSION
+cp branding/stamp-os-release.sh archiso/airootfs/root/branding/stamp-os-release.sh
+chmod +x archiso/airootfs/root/branding/stamp-os-release.sh
+CHURROS_VERSION=$(tr -d '[:space:]' < VERSION)
+bash branding/stamp-os-release.sh \
+    archiso/airootfs/root/branding/files/os-release \
+    "$CHURROS_VERSION"
+
 if [ -d branding/grub-theme ]; then
     cp -r branding/grub-theme \
         archiso/airootfs/root/branding/grub-theme

--- a/scripts/cli/check.sh
+++ b/scripts/cli/check.sh
@@ -426,6 +426,55 @@ else
     notice "msgfmt not available (gettext package)"
 fi
 
+# ---------------------------------------------------------- Distro version
+
+section "Distro version"
+
+if [ ! -f VERSION ]; then
+    fail "VERSION missing at repo root"
+else
+    ver=$(tr -d '[:space:]' < VERSION)
+    if [[ ! "$ver" =~ ^[0-9]+(\.[0-9]+)*$ ]]; then
+        fail "VERSION must be dotted numeric (got '$ver')"
+    else
+        pass "VERSION=$ver"
+    fi
+fi
+
+if grep -q 'include_str!("../../../VERSION")' rust/services/src/version.rs 2>/dev/null; then
+    pass "churros-services bakes VERSION at compile time"
+else
+    fail "rust/services/src/version.rs must include_str the repo VERSION file"
+fi
+
+if grep -qE 'const VERSION:[[:space:]]*&str[[:space:]]*=[[:space:]]*"[0-9]' rust/churros-welcome/src/footer.rs; then
+    fail "welcome footer has a hardcoded version; use churros_services::version::distro()"
+elif grep -q 'churros_services::version::distro' rust/churros-welcome/src/footer.rs; then
+    pass "welcome footer reads churros_services::version::distro"
+else
+    fail "welcome footer must call churros_services::version::distro()"
+fi
+
+if grep -qE 'fn version\(\) -> &' rust/preferences/src/services/about.rs \
+    && grep -q 'churros_services::version::distro' rust/preferences/src/services/about.rs; then
+    pass "Settings About reads churros_services::version::distro"
+else
+    fail "preferences AboutService::version must call churros_services::version::distro()"
+fi
+
+if [ -f branding/stamp-os-release.sh ]; then
+    pass "branding/stamp-os-release.sh present"
+else
+    fail "branding/stamp-os-release.sh missing"
+fi
+
+if grep -q 'stamp-os-release.sh' branding/customize_airootfs.sh \
+    && grep -q 'stamp-os-release.sh' scripts/cli/build.sh; then
+    pass "ISO build stamps os-release from VERSION"
+else
+    fail "build.sh and customize_airootfs.sh must stamp os-release from VERSION"
+fi
+
 # --------------------------------------------------------------- Hygiene
 
 section "Repository hygiene"


### PR DESCRIPTION
El footer de welcome tenía un número escrito a mano y no seguía al archivo VERSION. Las apps leen ahora esa fuente al compilar (churros_services::version) y el build de la ISO escribe el mismo valor en os-release. ./churros check falla si el pie o Acerca de vuelven a un literal.