### PR TITLE
feat: abrir las apps de la distro en el host

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,7 @@
 ./churros run --fresh  # Reset OVMF_VARS.fd so UEFI boots from CD-ROM instead of an existing install
 ./churros clean      # Remove work/ and out/ (also runs sudo rm -rf)
 ./churros check      # Static checks: bash, python, package list, niri autostart, Calamares branding, po files
+./churros apps       # Open distro apps on the host (GTK preview is dummy; Calamares uses a tmp overlay)
 ./churros doctor     # Check for mkarchiso, qemu, xorriso, mksquashfs, mcopy, mkinitcpio
 ./scripts/build-calamares.sh  # Build Calamares .pkg.tar.zst from AUR into archiso/packages/
 ./scripts/build-aur.sh        # Build python-pywal + waypaper + yay AUR packages
@@ -34,7 +35,7 @@ A trap on EXIT cleans generated files out of `archiso/airootfs/` (`root/customiz
 
 There are no unit tests yet. Two layers of verification exist today.
 
-`./churros check` runs the static checks (`scripts/cli/check.sh`): bash syntax, shellcheck at error level, Python syntax, duplicate entries in `packages.x86_64`, commands spawned by niri that resolve to a binary/crate/package, desktop `Exec`/`TryExec` resolution, Calamares exec order and shellprocess configs, Calamares branding (`componentName`, slideshow API 2, image files), local AUR extras listed in `netinstall.yaml`, and `msgfmt --check` on `po/*.po`. It needs no ISO build and runs in seconds. The same script runs in CI (`.github/workflows/ci.yml`) on every push to `main` and every pull request.
+`./churros check` runs the static checks (`scripts/cli/check.sh`): bash syntax, shellcheck at error level, Python syntax, duplicate entries in `packages.x86_64`, commands spawned by niri that resolve to a binary/crate/package, desktop `Exec`/`TryExec` resolution, Calamares exec order and shellprocess configs, Calamares branding (`componentName`, slideshow API 2, image files), Calamares host preview (`./churros apps calamares`), local AUR extras listed in `netinstall.yaml`, and `msgfmt --check` on `po/*.po`. It needs no ISO build and runs in seconds. The same script runs in CI (`.github/workflows/ci.yml`) on every push to `main` and every pull request.
 
 Behaviour on the live system is verified in QEMU:
 
@@ -59,7 +60,7 @@ rust/                         Rust workspace (apps portadas a gtk4-rs/libadwaita
   popups/                     Crate de los popups (binario churros-popup + toggle nativo)
   control-center/             Crate del control center (binario churros-control-center)
 scripts/
-  cli/                        build.sh, run.sh, clean.sh, doctor.sh, info.sh, version.sh, logo.sh
+  cli/                        build.sh, run.sh, clean.sh, check.sh, doctor.sh, apps.sh, info.sh, version.sh, logo.sh
   build-calamares.sh          Produces archiso/packages/calamares-*.pkg.tar.zst
   build-aur.sh                Produces python-pywal + waypaper + yay pkgs
   build-rust.sh               Compiles rust/* crates -> archiso/airootfs/usr/bin/
@@ -77,6 +78,7 @@ installer/
   calamares/settings.conf     Instance + sequence definition (see below)
   calamares/modules/*.conf    One .conf per Calamares module
   calamares/modules/*.yaml    netinstall package groups
+  calamares/preview/          Host-only overlay for ./churros apps calamares (not copied to the ISO)
   apply-calamares.sh          Copies config + polkit rule into airootfs
 docs/                         Project documentation
 ```

--- a/churros
+++ b/churros
@@ -15,6 +15,7 @@ PUBLIC_COMMANDS=(
     info
     version
     logo
+    apps
 )
 
 run_script() {
@@ -61,6 +62,7 @@ show_help() {
     printf "  %-12s %s\n" "run"     "Build (if needed) and launch QEMU"
     printf "  %-12s %s\n" "clean"   "Remove build artifacts"
     printf "  %-12s %s\n" "check"   "Run static checks over the repository"
+    printf "  %-12s %s\n" "apps"    "Open distro apps on the host (no ISO)"
     printf "  %-12s %s\n" "doctor"  "Check development environment"
     printf "  %-12s %s\n" "info"    "Display project information"
     printf "  %-12s %s\n" "version" "Display CLI version"
@@ -78,6 +80,7 @@ show_help() {
     echo "  ./churros run --clean"
     echo "  ./churros check"
     echo "  ./churros doctor"
+    echo "  ./churros apps calamares"
     echo
 }
 

--- a/docs/apps.md
+++ b/docs/apps.md
@@ -169,11 +169,25 @@ Hoy cada app tiene su propio CSS. A largo plazo convendría un crate o styleshee
 # Development
 
 1. Edita el crate en `rust/<app>/`.
-2. Compila en el host:
+2. Ábrelo en el host (sin ISO):
 
 ```bash
-cargo build --release --manifest-path rust/Cargo.toml
+./churros apps doctor
+./churros apps welcome
+./churros apps settings
+./churros apps control-center
+./churros apps popup audio
 ```
+
+Compila desde `rust/`. Los crates resuelven assets a `rust/<crate>/assets/` si no existe `/usr/share/churros/`. Hace falta sesión gráfica. Por defecto el modo preview no escribe configs del host ni ejecuta apagar/red/audio/gsettings; `--live-host` sí lo haría.
+
+El instalador se previsualiza igual:
+
+```bash
+./churros apps calamares
+```
+
+Usa un overlay temporal: no toca `/etc/calamares`, no particiona, no pide Polkit y no reinicia el host. `./churros check` no abre ventanas; valida que el branding de Calamares cargue (YAML, imágenes, API del slideshow) y que el preview no cargue el módulo de particiones.
 
 3. Para verlo en el Live:
 
@@ -181,8 +195,6 @@ cargo build --release --manifest-path rust/Cargo.toml
 ./churros build
 ./churros run
 ```
-
-`./churros check` no compila Rust; valida scripts, paquetes, desktop entries y que los `spawn` de Niri resuelvan a un binario, crate con `deploy = true` o paquete de la ISO.
 
 ---
 

--- a/docs/branding.md
+++ b/docs/branding.md
@@ -50,7 +50,7 @@ branding
 └── ui-guidelines.md
 ```
 
-Los wallpapers, logos de escritorio y Fastfetch viven en `archiso/airootfs/usr/share/churros/`. Plymouth y un tema propio de greetd aún no están. El branding de Calamares está en `installer/calamares/branding/churros/`.
+Los wallpapers, logos de escritorio y Fastfetch viven en `archiso/airootfs/usr/share/churros/`. Plymouth y un tema propio de greetd aún no están. El branding de Calamares está en `installer/calamares/branding/churros/`. Preview en el host: `./churros apps calamares`.
 
 ---
 
@@ -181,6 +181,14 @@ Permitirá personalizar completamente la animación de arranque.
 El branding de Calamares está en `installer/calamares/branding/churros/` (`branding.desc`, `stylesheet.qss`, `show.qml`, `calamares-sidebar.qml`, logo SVG). Calamares sale del proceso si `componentName` no coincide con la carpeta, si una imagen de `images:` no existe o si el QML del slideshow falta. `./churros check` cubre esos casos.
 
 El slideshow usa la API 2 de Calamares (`Presentation` / `Slide`, `onActivate` / `onLeave`). `Presentation` no rellena el panel: `show.qml` pone un `Rectangle` `#0F0F10` detrás (no es un `Slide`). El QSS no pinta `QWidget` global. `PartitionLabelsView` rellena `palette().window()` y upstream pinta negro/`Qt::gray`; `installer/patches/calamares-partition-labels.patch` elige el texto según ese fondo para poder dejar las leyendas en oscuro. La página de particiones (`ChoicePage`, `PrettyRadioButton`) sí se pinta a oscuro para que Erase/Manual no queden en blanco sobre blanco. El paso activo del sidebar lo pinta un delegate C++ (`sidebar: widget`); `calamares-sidebar.qml` queda para un cambio posterior. Colores y radios siguen las apps GTK (fondo `#0F0F10`, acento `#F97316`, Inter). No se usa `productWallpaper` (Calamares lo repite de fondo y queda ilegible).
+
+Para verlo en el host, sin ISO:
+
+```bash
+./churros apps calamares
+```
+
+Ese comando no carga particiones ni aplica teclado/zona horaria a la sesión. `installer/calamares/preview/` es solo para ese comando; `apply-calamares.sh` no lo copia a la ISO.
 
 ---
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -134,6 +134,28 @@ Comprueba que las herramientas del entorno de desarrollo estén instaladas (`mka
 
 ---
 
+## apps
+
+Abre las apps propias de ChurrOS en el host, sin construir la ISO ni QEMU.
+
+```bash
+./churros apps
+./churros apps doctor
+./churros apps welcome
+./churros apps settings
+./churros apps control-center
+./churros apps popup audio
+./churros apps calamares
+```
+
+Los targets GTK (`welcome`, `settings`, `control-center`, `popup`) se compilan desde `rust/`. Hace falta sesión gráfica y gtk4/libadwaita. Por defecto corren en modo preview: `HOME` es un directorio temporal y los comandos que cambian el sistema (volumen, red, energía, gsettings, pkill) no se ejecutan. Aparecen como `[churros-dev] blocked:` en stderr. `--live-host` desactiva ese aislamiento.
+
+`calamares` copia la config del repo a un directorio temporal y lanza el instalador con `-c` sobre ese overlay: no escribe `/etc/calamares`, no usa `sudo`, no pide contraseña, no abre la página de particiones (eso dispara Polkit/KPMCore contra discos reales) y no aplica teclado ni zona horaria a esta sesión. El paso de instalar es un `sleep` (para ver el slideshow) y la página final no ofrece reiniciar. El overlay incluye `qml/` del paquete extraído. `--live-host` está prohibido con este target.
+
+No sustituye `./churros run`.
+
+---
+
 ## info
 
 Muestra información del proyecto y del entorno (versión, rama, arquitectura y directorios).

--- a/docs/project-structure.md
+++ b/docs/project-structure.md
@@ -101,10 +101,12 @@ installer
 ├── apply-calamares.sh
 └── calamares/
     ├── settings.conf
+    ├── branding/churros/
+    ├── preview/            # solo ./churros apps calamares; no va a la ISO
     └── modules/
 ```
 
-`apply-calamares.sh` despliega la config y la regla polkit al airootfs durante el build.
+`apply-calamares.sh` despliega la config y la regla polkit al airootfs durante el build. `preview/` no se copia.
 
 ---
 
@@ -118,7 +120,7 @@ Traducciones gettext (`*.po`). `./churros check` las valida con `msgfmt --check`
 
 Scripts de desarrollo. No forman parte del sistema instalado.
 
-- `scripts/cli/` — subcomandos de `./churros` (`build`, `run`, `check`, `doctor`, …)
+- `scripts/cli/` — subcomandos de `./churros` (`build`, `run`, `check`, `apps`, `doctor`, …)
 - `scripts/build-rust.sh`, `build-calamares.sh`, `build-aur.sh`, `build-grub-theme.sh`
 
 ---

--- a/installer/calamares/preview/finished.conf
+++ b/installer/calamares/preview/finished.conf
@@ -1,0 +1,4 @@
+# Host preview: never offer reboot/shutdown of this machine.
+---
+restartNowMode: never
+notifyOnFinished: false

--- a/installer/calamares/preview/keyboard.conf
+++ b/installer/calamares/preview/keyboard.conf
@@ -1,0 +1,10 @@
+# Host preview: do not push the layout to this session (locale1 / setxkbmap).
+---
+defaultKeyboardModel: "pc105"
+defaultLayout: "us"
+useLocale1: false
+writeEtcDefaultKeyboard: false
+guessLayout: false
+configure:
+    kwin: false
+    gnome: false

--- a/installer/calamares/preview/locale.conf
+++ b/installer/calamares/preview/locale.conf
@@ -1,0 +1,6 @@
+# Host preview: do not call timedatectl / GeoIP on this machine.
+---
+region: "America"
+zone: "New_York"
+adjustLiveTimezone: false
+useSystemTimezone: false

--- a/installer/calamares/preview/netinstall.conf
+++ b/installer/calamares/preview/netinstall.conf
@@ -1,0 +1,8 @@
+# Host preview: groupsUrl is rewritten to the overlay yaml by apps.sh.
+---
+label:
+    sidebar: Paquetes
+    title: Selección de paquetes
+
+groupsUrl:
+    - file:///etc/calamares/modules/netinstall.yaml

--- a/installer/calamares/preview/settings.conf
+++ b/installer/calamares/preview/settings.conf
@@ -1,0 +1,36 @@
+# Host-only overlay for `./churros apps calamares`.
+# apply-calamares.sh does not copy this directory into the ISO.
+#
+# No partition page: KPMCore talks to polkit on startup and would
+# prompt for a password while scanning real disks.
+---
+modules-search:
+  - local
+
+instances:
+  - id: preview
+    module: shellprocess
+    config: shellprocess-preview.conf
+
+sequence:
+  - show:
+      - welcome
+      - locale
+      - keyboard
+      - users
+      - netinstall
+      - summary
+  - exec:
+      - shellprocess@preview
+  - show:
+      - finished
+
+branding: churros
+
+prompt-install: true
+dont-chroot: true
+oem-setup: false
+disable-cancel: false
+disable-cancel-during-exec: false
+hide-back-and-next-during-exec: false
+quit-at-end: false

--- a/installer/calamares/preview/shellprocess-preview.conf
+++ b/installer/calamares/preview/shellprocess-preview.conf
@@ -1,0 +1,10 @@
+# Host-only. Copied into the preview config dir, not into the ISO.
+# Sleeps so the slideshow is visible; does not write files.
+---
+dontChroot: true
+timeout: 30
+verbose: true
+
+script:
+  - command: "sleep 8"
+    timeout: 20

--- a/installer/calamares/preview/welcome.conf
+++ b/installer/calamares/preview/welcome.conf
@@ -1,0 +1,11 @@
+# Host preview: no disk, network or power probes.
+---
+showSupportUrl: true
+showKnownIssuesUrl: true
+showReleaseNotesUrl: true
+showDonateUrl: false
+
+requirements:
+  requiredRam: 0.5
+  check:
+    - ram

--- a/rust/churros-welcome/src/actions.rs
+++ b/rust/churros-welcome/src/actions.rs
@@ -99,6 +99,20 @@ fn desktop_exec(app_id: &str) -> Option<String> {
 }
 
 fn launch_installer(parent: &gtk::Button) {
+    if std::env::var("CHURROS_DEV").ok().as_deref() == Some("1") {
+        eprintln!("[churros-dev] blocked: launch calamares");
+        let dialog = gtk::AlertDialog::builder()
+            .message("Preview: the installer is not launched on the host.")
+            .modal(true)
+            .build();
+        if let Some(root) = parent.root().and_downcast::<gtk::Window>() {
+            dialog.show(Some(&root));
+        } else {
+            dialog.show(None::<&gtk::Window>);
+        }
+        return;
+    }
+
     match desktop_exec("calamares.desktop") {
         Some(exec) => {
             let launched = Command::new("sh")

--- a/rust/services/src/dev.rs
+++ b/rust/services/src/dev.rs
@@ -1,0 +1,184 @@
+// Host-preview dry-run (CHURROS_DEV=1). Reads stay live; writes are logged
+// and skipped so ./churros apps cannot change the developer machine.
+
+pub fn enabled() -> bool {
+    matches!(std::env::var("CHURROS_DEV").as_deref(), Ok("1"))
+}
+
+pub fn log_blocked(cmd: &[&str]) {
+    eprintln!("[churros-dev] blocked: {}", cmd.join(" "));
+}
+
+fn bin_name(cmd: &str) -> &str {
+    std::path::Path::new(cmd)
+        .file_name()
+        .and_then(|s| s.to_str())
+        .unwrap_or(cmd)
+}
+
+fn has_arg(args: &[&str], needle: &str) -> bool {
+    args.iter().any(|a| *a == needle)
+}
+
+fn nmcli_mutates(args: &[&str]) -> bool {
+    let mut i = 0;
+    while i < args.len() {
+        let a = args[i];
+        if a == "-f" || a == "--fields" || a == "-g" || a == "--get-values" {
+            i += 2;
+            continue;
+        }
+        if a.starts_with('-') {
+            i += 1;
+            continue;
+        }
+        match a {
+            "connect" | "disconnect" | "delete" | "modify" | "add" | "edit" | "up" | "down"
+            | "rescan" | "reload" | "on" | "off" => return true,
+            _ => i += 1,
+        }
+    }
+    false
+}
+
+fn systemctl_mutates(args: &[&str]) -> bool {
+    const READS: &[&str] = &[
+        "is-active",
+        "is-enabled",
+        "is-failed",
+        "status",
+        "show",
+        "cat",
+        "list-units",
+        "list-unit-files",
+        "list-timers",
+        "show-environment",
+        "--version",
+        "help",
+    ];
+    !args.iter().any(|a| READS.contains(a))
+}
+
+fn bluetoothctl_mutates(args: &[&str]) -> bool {
+    const READS: &[&str] = &["show", "devices", "info", "list", "paired-devices", "help"];
+    let mut i = 0;
+    while i < args.len() {
+        let a = args[i];
+        if a == "--timeout" {
+            i += 2;
+            continue;
+        }
+        if a.starts_with('-') {
+            i += 1;
+            continue;
+        }
+        return !READS.contains(&a);
+    }
+    false
+}
+
+/// True when running the command would change this machine.
+pub fn is_mutation(cmd: &[&str]) -> bool {
+    if cmd.is_empty() {
+        return true;
+    }
+    let bin = bin_name(cmd[0]);
+    let args = &cmd[1..];
+    match bin {
+        "nmcli" => nmcli_mutates(args),
+        "wpctl" => args.iter().any(|a| a.starts_with("set-")),
+        "brightnessctl" => has_arg(args, "set") || has_arg(args, "s"),
+        "bluetoothctl" => bluetoothctl_mutates(args),
+        "rfkill" => has_arg(args, "block") || has_arg(args, "unblock"),
+        "systemctl" => systemctl_mutates(args),
+        "loginctl" => args.iter().any(|a| {
+            a.starts_with("lock") || a.starts_with("terminate") || a.starts_with("kill")
+        }),
+        "gsettings" => matches!(args.first().copied(), Some("set") | Some("reset")),
+        "dconf" => matches!(args.first().copied(), Some("write") | Some("reset")),
+        "timedatectl" => args.iter().any(|a| a.starts_with("set-")),
+        "ufw" => !has_arg(args, "status"),
+        "pacman" => !args.iter().any(|a| *a == "-Q" || a.starts_with("-Q")),
+        "flatpak" => has_arg(args, "update") || has_arg(args, "install") || has_arg(args, "remove"),
+        "swapon" => !args.iter().any(|a| *a == "--show"),
+        "niri" => has_arg(args, "action") || has_arg(args, "quit"),
+        "hyprctl" => has_arg(args, "dispatch"),
+        "id" | "date" | "pgrep" | "fc-list" | "lspci" | "curl" | "notify-send" => false,
+        "xdg-open" | "thunar" => false,
+        "sh" | "bash" => !args.iter().any(|a| a.contains("command -v")),
+        "pkill" | "kill" | "killall" | "pkexec" | "sudo" | "churros-pkexec" | "calamares"
+        | "wal" | "makoctl" | "swaymsg" | "swaybg" | "swaylock" | "swayidle" | "wlsunset"
+        | "waybar" | "install" | "foot" | "churros-apply-wallpaper" | "waypaper"
+        | "churros-update-utils" | "churros-pick-image" => true,
+        _ => true,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::is_mutation;
+
+    #[test]
+    fn reads_are_live() {
+        assert!(!is_mutation(&["nmcli", "-t", "-f", "DEVICE,TYPE", "device"]));
+        assert!(!is_mutation(&["nmcli", "radio", "wifi"]));
+        assert!(!is_mutation(&["wpctl", "status"]));
+        assert!(!is_mutation(&["wpctl", "get-volume", "@DEFAULT_AUDIO_SINK@"]));
+        assert!(!is_mutation(&["brightnessctl", "g"]));
+        assert!(!is_mutation(&["bluetoothctl", "show"]));
+        assert!(!is_mutation(&["bluetoothctl", "devices"]));
+        assert!(!is_mutation(&["systemctl", "is-active", "NetworkManager"]));
+        assert!(!is_mutation(&[
+            "systemctl",
+            "--user",
+            "is-enabled",
+            "churros-update.timer"
+        ]));
+        assert!(!is_mutation(&[
+            "gsettings",
+            "get",
+            "org.gnome.desktop.interface",
+            "gtk-theme"
+        ]));
+        assert!(!is_mutation(&["id", "-u"]));
+        assert!(!is_mutation(&["swapon", "--show", "--noheadings"]));
+        assert!(!is_mutation(&["rfkill", "list", "bluetooth"]));
+        assert!(!is_mutation(&["pacman", "-Q"]));
+        assert!(!is_mutation(&[
+            "sh",
+            "-c",
+            "command -v swaylock >/dev/null 2>&1"
+        ]));
+    }
+
+    #[test]
+    fn writes_are_dummy() {
+        assert!(is_mutation(&["nmcli", "radio", "wifi", "off"]));
+        assert!(is_mutation(&["nmcli", "device", "disconnect", "wlan0"]));
+        assert!(is_mutation(&["nmcli", "device", "wifi", "connect", "x"]));
+        assert!(is_mutation(&["wpctl", "set-volume", "@DEFAULT_AUDIO_SINK@", "50%"]));
+        assert!(is_mutation(&["brightnessctl", "set", "50%"]));
+        assert!(is_mutation(&["bluetoothctl", "power", "off"]));
+        assert!(is_mutation(&["bluetoothctl", "connect", "AA:BB"]));
+        assert!(is_mutation(&["systemctl", "poweroff"]));
+        assert!(is_mutation(&["systemctl", "--user", "enable", "--now", "x.timer"]));
+        assert!(is_mutation(&[
+            "gsettings",
+            "set",
+            "org.gnome.desktop.interface",
+            "color-scheme",
+            "prefer-dark"
+        ]));
+        assert!(is_mutation(&["pkill", "waybar"]));
+        assert!(is_mutation(&["pkexec", "calamares"]));
+        assert!(is_mutation(&["loginctl", "lock-session"]));
+        assert!(is_mutation(&["niri", "msg", "action", "quit"]));
+        assert!(is_mutation(&[
+            "sh",
+            "-c",
+            "for pid in $(pgrep -x gnome-shell); do kill -USR1 $pid; done"
+        ]));
+        assert!(is_mutation(&["foot", "-e", "sudo", "pacman", "-Syu"]));
+        assert!(is_mutation(&["churros-apply-wallpaper", "/tmp/wp.jpg"]));
+    }
+}

--- a/rust/services/src/lib.rs
+++ b/rust/services/src/lib.rs
@@ -7,6 +7,7 @@ pub mod audio;
 pub mod battery;
 pub mod bluetooth;
 pub mod brightness;
+pub mod dev;
 pub mod ethernet;
 pub mod jsonc;
 pub mod power;
@@ -27,6 +28,11 @@ pub type RunOut = (i32, String, String);
 /// Devuelve None si falla el spawn, el timeout se agota o la salida no es UTF-8
 /// (equivalente al `try/except` de los módulos Python).
 pub fn run(cmd: &[&str], timeout_ms: u64) -> Option<RunOut> {
+    if dev::enabled() && dev::is_mutation(cmd) {
+        dev::log_blocked(cmd);
+        return Some((0, String::new(), String::new()));
+    }
+
     let mut child = Command::new(cmd[0])
         .args(&cmd[1..])
         .stdout(Stdio::piped())
@@ -71,6 +77,11 @@ pub fn run(cmd: &[&str], timeout_ms: u64) -> Option<RunOut> {
 
 /// Ejecuta un comando al vuelo (fire-and-forget, equivale a subprocess.Popen).
 pub fn spawn(cmd: &[&str]) {
+    if dev::enabled() {
+        dev::log_blocked(cmd);
+        return;
+    }
+
     let _ = Command::new(cmd[0])
         .args(&cmd[1..])
         .stdout(Stdio::null())

--- a/scripts/cli/apps-dev-stub.sh
+++ b/scripts/cli/apps-dev-stub.sh
@@ -1,0 +1,150 @@
+#!/usr/bin/env bash
+# Symlinked as nmcli/gsettings/systemctl/... by ./churros apps.
+# Reads exec the real binary; writes print a log line and exit 0.
+set -euo pipefail
+
+NAME="$(basename "$0")"
+REAL="$(PATH="/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/bin" command -v "$NAME" || true)"
+
+is_mutation() {
+    case "$NAME" in
+        nmcli)
+            for a in "$@"; do
+                case "$a" in
+                    -f|--fields|-g|--get-values) ;;
+                    -*) ;;
+                    connect|disconnect|delete|modify|add|edit|up|down|rescan|reload|on|off)
+                        return 0
+                        ;;
+                esac
+            done
+            return 1
+            ;;
+        wpctl)
+            for a in "$@"; do
+                case "$a" in set-*) return 0 ;; esac
+            done
+            return 1
+            ;;
+        brightnessctl)
+            for a in "$@"; do
+                case "$a" in set|s) return 0 ;; esac
+            done
+            return 1
+            ;;
+        bluetoothctl)
+            skip=0
+            for a in "$@"; do
+                if [ "$skip" -eq 1 ]; then skip=0; continue; fi
+                case "$a" in
+                    --timeout) skip=1 ;;
+                    -*) ;;
+                    show|devices|info|list|paired-devices|help) return 1 ;;
+                    *) return 0 ;;
+                esac
+            done
+            return 1
+            ;;
+        rfkill)
+            for a in "$@"; do
+                case "$a" in block|unblock) return 0 ;; esac
+            done
+            return 1
+            ;;
+        systemctl)
+            for a in "$@"; do
+                case "$a" in
+                    is-active|is-enabled|is-failed|status|show|cat|list-units|list-unit-files|list-timers|show-environment|--version|help)
+                        return 1
+                        ;;
+                esac
+            done
+            return 0
+            ;;
+        loginctl)
+            for a in "$@"; do
+                case "$a" in lock*|terminate*|kill*) return 0 ;; esac
+            done
+            return 1
+            ;;
+        gsettings)
+            case "${1-}" in set|reset) return 0 ;; *) return 1 ;; esac
+            ;;
+        dconf)
+            case "${1-}" in write|reset) return 0 ;; *) return 1 ;; esac
+            ;;
+        timedatectl)
+            for a in "$@"; do
+                case "$a" in set-*) return 0 ;; esac
+            done
+            return 1
+            ;;
+        localectl)
+            for a in "$@"; do
+                case "$a" in list-*|status) return 1 ;; esac
+            done
+            return 0
+            ;;
+        ufw)
+            for a in "$@"; do
+                [ "$a" = status ] && return 1
+            done
+            return 0
+            ;;
+        pacman)
+            for a in "$@"; do
+                case "$a" in -Q|-Q*) return 1 ;; esac
+            done
+            return 0
+            ;;
+        flatpak)
+            for a in "$@"; do
+                case "$a" in update|install|remove) return 0 ;; esac
+            done
+            return 1
+            ;;
+        pkill|kill|killall|pkexec|sudo|churros-pkexec|calamares|wal|makoctl|swaymsg|swaybg|swaylock|swayidle|wlsunset|waybar|install|setxkbmap|loadkeys)
+            return 0
+            ;;
+        niri)
+            for a in "$@"; do
+                case "$a" in action|quit) return 0 ;; esac
+            done
+            return 1
+            ;;
+        hyprctl)
+            for a in "$@"; do
+                [ "$a" = dispatch ] && return 0
+            done
+            return 1
+            ;;
+        sh|bash)
+            # lock_screen which() uses `sh -c 'command -v …'`; allow that read.
+            for a in "$@"; do
+                case "$a" in
+                    *'command -v'*) return 1 ;;
+                esac
+            done
+            return 0
+            ;;
+        *)
+            return 0
+            ;;
+    esac
+}
+
+if is_mutation "$@"; then
+    printf '[churros-dev] blocked: %s' "$NAME" >&2
+    if [ "$#" -gt 0 ]; then
+        printf ' %s' "$@" >&2
+    fi
+    printf '\n' >&2
+    exit 0
+fi
+
+if [ -z "$REAL" ]; then
+    printf '[churros-dev] no real binary for %s\n' "$NAME" >&2
+    exit 0
+fi
+
+exec "$REAL" "$@"

--- a/scripts/cli/apps.sh
+++ b/scripts/cli/apps.sh
@@ -1,0 +1,503 @@
+#!/usr/bin/env bash
+#
+# Open distro apps on the host (no ISO, no QEMU). GTK crates in dummy
+# preview (CHURROS_DEV + throwaway HOME + PATH stubs); Calamares via a
+# throwaway config overlay that cannot install.
+#
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+cd "$REPO_ROOT"
+
+CARGO_MANIFEST="$REPO_ROOT/rust/Cargo.toml"
+CALAMARES_SRC="$REPO_ROOT/installer/calamares"
+PREVIEW_DIR="$CALAMARES_SRC/preview"
+POPUPS=(network audio bluetooth power brightness battery)
+
+LIVE_HOST=0
+TMP_DIRS=()
+CALAMARES_BIN=""
+CALAMARES_PREFIX=""
+
+cleanup() {
+    local dir
+    for dir in "${TMP_DIRS[@]+"${TMP_DIRS[@]}"}"; do
+        rm -rf "$dir"
+    done
+}
+trap cleanup EXIT
+
+die() {
+    printf 'Error: %s\n' "$1" >&2
+    exit 1
+}
+
+require_not_root() {
+    if [ "$(id -u)" -eq 0 ]; then
+        die "./churros apps must not run as root"
+    fi
+}
+
+have_display() {
+    [ -n "${WAYLAND_DISPLAY:-}" ] || [ -n "${DISPLAY:-}" ]
+}
+
+print_check() {
+    local ok=$1
+    shift
+    if [ "$ok" -eq 1 ]; then
+        printf '✓ %s\n' "$*"
+    else
+        printf '✗ %s\n' "$*"
+    fi
+}
+
+calamares_pkg() {
+    if [ ! -d "$REPO_ROOT/archiso/packages" ]; then
+        return 0
+    fi
+    find "$REPO_ROOT/archiso/packages" -maxdepth 1 -name 'calamares-[0-9]*.pkg.tar.zst' -print -quit
+}
+
+show_help() {
+    cat <<'EOF'
+Usage:
+  ./churros apps
+  ./churros apps doctor
+  ./churros apps welcome|settings|control-center|calamares
+  ./churros apps popup <audio|network|bluetooth|brightness|battery|power>
+
+Open ChurrOS apps on this machine without building the ISO.
+
+GTK apps compile from rust/. By default they run in preview mode:
+writes go to a throwaway HOME, and commands that change the system
+(volume, network, power, gsettings, pkill) are dummy. Watch stderr
+for lines starting with [churros-dev].
+
+Calamares uses a temporary config: no /etc/calamares, no partition
+page, no polkit, no live timezone/keyboard, no reboot. Install is sleep.
+
+  --live-host   GTK only; buttons CAN change this machine. Rejected
+                for calamares.
+
+This does not replace ./churros run.
+EOF
+}
+
+run_doctor() {
+    local ok=1 display_ok=0 cargo_ok=0 gtk_ok=0 cala_ok=0 pkg
+
+    echo "Apps host diagnostics"
+    echo
+
+    if have_display; then
+        display_ok=1
+        if [ -n "${WAYLAND_DISPLAY:-}" ]; then
+            print_check 1 "display (Wayland)"
+        else
+            print_check 1 "display (X11)"
+        fi
+    else
+        print_check 0 "display — set WAYLAND_DISPLAY or DISPLAY"
+        ok=0
+    fi
+
+    if command -v cargo >/dev/null 2>&1; then
+        cargo_ok=1
+        print_check 1 "cargo"
+    else
+        print_check 0 "cargo — pacman -S rust"
+        ok=0
+    fi
+
+    if command -v pkg-config >/dev/null 2>&1 \
+        && pkg-config --exists gtk4 libadwaita-1; then
+        gtk_ok=1
+        print_check 1 "gtk4 + libadwaita"
+    else
+        print_check 0 "gtk4 + libadwaita — pacman -S gtk4 libadwaita"
+        ok=0
+    fi
+
+    if command -v calamares >/dev/null 2>&1; then
+        cala_ok=1
+        print_check 1 "calamares ($(command -v calamares))"
+    else
+        pkg="$(calamares_pkg)"
+        if [ -n "$pkg" ]; then
+            cala_ok=1
+            print_check 1 "calamares package ($pkg)"
+        else
+            print_check 0 "calamares — install it or run ./scripts/build-calamares.sh"
+        fi
+    fi
+
+    echo
+    if [ -e "$REPO_ROOT/work" ] && [ ! -w "$REPO_ROOT/work" ]; then
+        echo "note: work/ is not writable (leftover from sudo mkarchiso)."
+        echo "      ./scripts/build-calamares.sh will use /tmp. Or run: ./churros clean"
+        echo
+    fi
+
+    if [ "$ok" -eq 1 ] && [ "$cala_ok" -eq 1 ]; then
+        echo "Diagnostics complete."
+        return 0
+    fi
+    if [ "$display_ok" -eq 1 ] && [ "$cargo_ok" -eq 1 ] && [ "$gtk_ok" -eq 1 ]; then
+        echo "GTK targets can run. Calamares preview needs a binary or local package."
+        return 0
+    fi
+    echo "Diagnostics found missing dependencies."
+    return 1
+}
+
+require_display() {
+    if ! have_display; then
+        die "no graphical session (WAYLAND_DISPLAY / DISPLAY). Try ./churros apps doctor"
+    fi
+}
+
+require_cargo() {
+    command -v cargo >/dev/null 2>&1 || die "cargo is not installed. pacman -S rust"
+}
+
+require_gtk() {
+    if command -v pkg-config >/dev/null 2>&1 && ! pkg-config --exists gtk4 libadwaita-1; then
+        die "gtk4/libadwaita not found. pacman -S gtk4 libadwaita"
+    fi
+}
+
+STUB_NAMES=(
+    nmcli wpctl brightnessctl bluetoothctl rfkill systemctl loginctl
+    gsettings dconf pkill kill killall pkexec sudo churros-pkexec
+    calamares wal timedatectl localectl ufw makoctl niri hyprctl swaymsg swaybg
+    swaylock swayidle wlsunset waybar install pacman flatpak
+    sh bash foot churros-apply-wallpaper waypaper churros-update-utils
+    churros-pick-image setxkbmap loadkeys
+)
+
+prepare_dev_sandbox() {
+    local stub name
+    stub="$REPO_ROOT/scripts/cli/apps-dev-stub.sh"
+    [ -x "$stub" ] || die "missing $stub"
+
+    DEV_HOME="$(mktemp -d /tmp/churros-dev-home.XXXXXX)"
+    DEV_BIN="$(mktemp -d /tmp/churros-dev-bin.XXXXXX)"
+    TMP_DIRS+=("$DEV_HOME" "$DEV_BIN")
+
+    mkdir -p "$DEV_HOME/.config" "$DEV_HOME/.local/share" \
+        "$DEV_HOME/.local/state" "$DEV_HOME/.cache"
+
+    for name in "${STUB_NAMES[@]}"; do
+        ln -s "$stub" "$DEV_BIN/$name"
+    done
+}
+
+CALAMARES_STUB_NAMES=(
+    pkexec sudo churros-pkexec timedatectl localectl setxkbmap loadkeys
+    systemctl loginctl reboot shutdown halt poweroff
+    mount umount mkfs mkfs.btrfs mkfs.ext4 mkfs.vfat mkfs.fat mkswap
+    parted sgdisk sfdisk wipefs dd cryptsetup
+    pacman
+)
+
+prepare_calamares_stubs() {
+    local stub name
+    stub="$REPO_ROOT/scripts/cli/apps-dev-stub.sh"
+    [ -x "$stub" ] || die "missing $stub"
+
+    DEV_BIN="$(mktemp -d /tmp/churros-dev-bin.XXXXXX)"
+    TMP_DIRS+=("$DEV_BIN")
+
+    for name in "${CALAMARES_STUB_NAMES[@]}"; do
+        ln -s "$stub" "$DEV_BIN/$name"
+    done
+}
+
+crate_bin_name() {
+    case "$1" in
+        churros-welcome) printf '%s\n' churros-welcome ;;
+        churros-settings) printf '%s\n' churros-settings ;;
+        churros-control-center) printf '%s\n' churros-control-center ;;
+        churros-popup) printf '%s\n' churros-popup ;;
+        *) die "unknown crate $1" ;;
+    esac
+}
+
+run_gtk_crate() {
+    local crate=$1 bin
+    shift
+    require_not_root
+    require_display
+    require_cargo
+    require_gtk
+
+    cargo build --manifest-path "$CARGO_MANIFEST" -p "$crate"
+    bin="$REPO_ROOT/rust/target/debug/$(crate_bin_name "$crate")"
+    [ -x "$bin" ] || die "cargo did not produce $bin"
+
+    if [ "$LIVE_HOST" -eq 1 ]; then
+        echo "WARNING: --live-host: buttons CAN change this machine."
+        echo
+        "$bin" "$@"
+        return
+    fi
+
+    prepare_dev_sandbox
+    echo "Preview mode: system changes are dummy. Host configs are not written."
+    echo "  HOME=$DEV_HOME"
+    echo "  Blocked commands log as [churros-dev] on stderr."
+    echo
+
+    # Keep WAYLAND_DISPLAY / XDG_RUNTIME_DIR / DBUS from the real session.
+    env \
+        CHURROS_DEV=1 \
+        HOME="$DEV_HOME" \
+        XDG_CONFIG_HOME="$DEV_HOME/.config" \
+        XDG_DATA_HOME="$DEV_HOME/.local/share" \
+        XDG_STATE_HOME="$DEV_HOME/.local/state" \
+        XDG_CACHE_HOME="$DEV_HOME/.cache" \
+        PATH="$DEV_BIN:$PATH" \
+        "$bin" "$@"
+}
+
+is_popup() {
+    local name=$1 p
+    for p in "${POPUPS[@]}"; do
+        if [ "$p" = "$name" ]; then
+            return 0
+        fi
+    done
+    return 1
+}
+
+# Extract the local Calamares package into a prefix. Host Qt/KF stay in use;
+# only Calamares libs, plugins and QML come from the archive.
+prepare_extracted_calamares() {
+    local pkg prefix qml plugins
+    pkg="$(calamares_pkg)"
+    [ -n "$pkg" ] || return 1
+    prefix="$(mktemp -d /tmp/churros-calamares-prefix.XXXXXX)"
+    TMP_DIRS+=("$prefix")
+    if command -v bsdtar >/dev/null 2>&1; then
+        bsdtar -xf "$pkg" -C "$prefix"
+    elif tar --help 2>/dev/null | grep -q -- --zstd; then
+        tar --zstd -xf "$pkg" -C "$prefix"
+    else
+        die "need bsdtar (or tar --zstd) to extract the Calamares package"
+    fi
+    CALAMARES_BIN="$prefix/usr/bin/calamares"
+    CALAMARES_PREFIX="$prefix"
+    [ -x "$CALAMARES_BIN" ] || die "extracted package has no usr/bin/calamares"
+
+    if [ -d "$prefix/usr/lib" ]; then
+        export LD_LIBRARY_PATH="$prefix/usr/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+    fi
+    for qml in "$prefix/usr/share/calamares/qml" "$prefix/usr/lib/qt6/qml" "$prefix/usr/lib/qt/qml"; do
+        if [ -d "$qml" ]; then
+            export QML2_IMPORT_PATH="$qml${QML2_IMPORT_PATH:+:$QML2_IMPORT_PATH}"
+            export QML_IMPORT_PATH="$qml${QML_IMPORT_PATH:+:$QML_IMPORT_PATH}"
+        fi
+    done
+    for plugins in "$prefix/usr/lib/qt6/plugins" "$prefix/usr/lib/qt/plugins"; do
+        if [ -d "$plugins" ]; then
+            export QT_PLUGIN_PATH="$plugins${QT_PLUGIN_PATH:+:$QT_PLUGIN_PATH}"
+        fi
+    done
+}
+
+resolve_calamares_bin() {
+    # Prefer the local package so the netinstall patch matches the ISO.
+    if prepare_extracted_calamares; then
+        return 0
+    fi
+    if command -v calamares >/dev/null 2>&1; then
+        CALAMARES_BIN="$(command -v calamares)"
+        CALAMARES_PREFIX=""
+        return 0
+    fi
+    die "calamares not in PATH and no archiso/packages/calamares-*.pkg.tar.zst. Run ./scripts/build-calamares.sh"
+}
+
+# -c DIR replaces SHARE/calamares, so DIR/qml must exist or Calamares exits.
+calamares_qml_src() {
+    local root
+    if [ -n "${CALAMARES_PREFIX:-}" ] && [ -d "$CALAMARES_PREFIX/usr/share/calamares/qml" ]; then
+        printf '%s\n' "$CALAMARES_PREFIX/usr/share/calamares/qml"
+        return 0
+    fi
+    if [ -n "${CALAMARES_BIN:-}" ]; then
+        root="$(cd "$(dirname "$CALAMARES_BIN")/.." && pwd)"
+        if [ -d "$root/share/calamares/qml" ]; then
+            printf '%s\n' "$root/share/calamares/qml"
+            return 0
+        fi
+    fi
+    if [ -d /usr/share/calamares/qml ]; then
+        printf '%s\n' /usr/share/calamares/qml
+        return 0
+    fi
+    return 1
+}
+
+# "local" in modules-search is $LIBDIR/calamares/modules (baked in as /usr/lib).
+# An extracted package lives elsewhere; put that path first.
+inject_extracted_modules_search() {
+    local settings=$1 modules_dir=$2
+    python3 - "$settings" "$modules_dir" <<'PY'
+from pathlib import Path
+import sys
+
+settings, modules_dir = Path(sys.argv[1]), sys.argv[2]
+text = settings.read_text(encoding="utf-8")
+needle = "modules-search:\n"
+if needle not in text:
+    sys.exit("settings.conf has no modules-search key")
+settings.write_text(text.replace(needle, needle + f"  - {modules_dir}\n", 1), encoding="utf-8")
+PY
+}
+
+run_calamares() {
+    local cfg branding_src qml_src modules_dir preview_conf
+
+    require_not_root
+    require_display
+
+    if [ "$LIVE_HOST" -eq 1 ]; then
+        die "--live-host is not allowed for calamares (would risk installing on this machine)"
+    fi
+
+    [ -f "$PREVIEW_DIR/settings.conf" ] || die "missing $PREVIEW_DIR/settings.conf"
+    [ -f "$PREVIEW_DIR/shellprocess-preview.conf" ] || die "missing $PREVIEW_DIR/shellprocess-preview.conf"
+    branding_src="$CALAMARES_SRC/branding/churros"
+    [ -f "$branding_src/branding.desc" ] || die "missing $branding_src/branding.desc"
+
+    resolve_calamares_bin
+    prepare_calamares_stubs
+
+    cfg="$(mktemp -d /tmp/churros-calamares-XXXXXX)"
+    TMP_DIRS+=("$cfg")
+
+    mkdir -p "$cfg/modules" "$cfg/branding/churros" "$cfg/cache" "$cfg/xdg-config"
+    cp "$PREVIEW_DIR/settings.conf" "$cfg/settings.conf"
+    cp "$CALAMARES_SRC/modules/"*.conf "$cfg/modules/"
+    cp "$CALAMARES_SRC/modules/"*.yaml "$cfg/modules/"
+    for preview_conf in "$PREVIEW_DIR"/*.conf; do
+        case "$(basename "$preview_conf")" in
+            settings.conf) continue ;;
+            *) cp "$preview_conf" "$cfg/modules/" ;;
+        esac
+    done
+    cp -a "$branding_src/." "$cfg/branding/churros/"
+
+    qml_src="$(calamares_qml_src)" || die "Calamares QML not found (expected usr/share/calamares/qml in the package)"
+    ln -s "$qml_src" "$cfg/qml"
+
+    if [ -n "${CALAMARES_PREFIX:-}" ]; then
+        modules_dir="$CALAMARES_PREFIX/usr/lib/calamares/modules"
+        [ -d "$modules_dir" ] || die "extracted package has no usr/lib/calamares/modules"
+        inject_extracted_modules_search "$cfg/settings.conf" "$modules_dir"
+    fi
+
+    python3 - "$cfg/modules/netinstall.conf" "$cfg/modules/netinstall.yaml" <<'PY'
+from pathlib import Path
+import sys
+
+conf, yaml_path = Path(sys.argv[1]), Path(sys.argv[2]).resolve()
+text = conf.read_text(encoding="utf-8")
+conf.write_text(
+    text.replace(
+        "file:///etc/calamares/modules/netinstall.yaml",
+        f"file://{yaml_path}",
+    ),
+    encoding="utf-8",
+)
+PY
+
+    echo "Calamares preview (UI only)."
+    echo "  config : $cfg"
+    echo "  binary : $CALAMARES_BIN"
+    echo "  No partition page, no polkit, no live timezone/keyboard, no reboot."
+    echo "  Install runs sleep. Nothing is written to /etc/calamares."
+    echo
+
+    (
+        cd "$cfg"
+        # Do not pass -X: that would mix in ~/.config/calamares.
+        env \
+            PATH="$DEV_BIN:$PATH" \
+            XDG_CACHE_HOME="$cfg/cache" \
+            XDG_CONFIG_HOME="$cfg/xdg-config" \
+            "$CALAMARES_BIN" -d -c "$cfg"
+    )
+}
+
+parse_args() {
+    local args=()
+    while [ $# -gt 0 ]; do
+        case "$1" in
+            --live-host)
+                LIVE_HOST=1
+                shift
+                ;;
+            -h | --help | help)
+                show_help
+                exit 0
+                ;;
+            --)
+                shift
+                args+=("$@")
+                break
+                ;;
+            -*)
+                die "unknown option: $1"
+                ;;
+            *)
+                args+=("$1")
+                shift
+                ;;
+        esac
+    done
+    if [ "${#args[@]}" -gt 0 ]; then
+        set -- "${args[@]}"
+    else
+        set --
+    fi
+    TARGET="${1-}"
+    shift || true
+    TARGET_ARGS=("$@")
+}
+
+require_not_root
+parse_args "$@"
+
+case "${TARGET:-}" in
+    "")
+        show_help
+        ;;
+    doctor)
+        run_doctor
+        ;;
+    welcome)
+        run_gtk_crate churros-welcome "${TARGET_ARGS[@]+"${TARGET_ARGS[@]}"}"
+        ;;
+    settings)
+        run_gtk_crate churros-settings "${TARGET_ARGS[@]+"${TARGET_ARGS[@]}"}"
+        ;;
+    control-center)
+        run_gtk_crate churros-control-center "${TARGET_ARGS[@]+"${TARGET_ARGS[@]}"}"
+        ;;
+    popup)
+        if [ "${#TARGET_ARGS[@]}" -lt 1 ]; then
+            die "usage: ./churros apps popup {network|audio|bluetooth|power|brightness|battery}"
+        fi
+        is_popup "${TARGET_ARGS[0]}" || die "unknown popup '${TARGET_ARGS[0]}'"
+        run_gtk_crate churros-popup "${TARGET_ARGS[@]}"
+        ;;
+    calamares)
+        run_calamares
+        ;;
+    *)
+        die "unknown target '${TARGET}'. Try ./churros apps"
+        ;;
+esac

--- a/scripts/cli/check.sh
+++ b/scripts/cli/check.sh
@@ -548,6 +548,34 @@ else
     fail "branding component would make Calamares exit"
 fi
 
+# ------------------------------------------- Calamares host preview (no ISO)
+
+section "Calamares host preview"
+
+PREVIEW=installer/calamares/preview
+if [ ! -f "$PREVIEW/settings.conf" ]; then
+    fail "$PREVIEW/settings.conf missing"
+else
+    preview_ok=1
+    if grep -E '^[[:space:]]+-[[:space:]]*partition[[:space:]]*$' "$PREVIEW/settings.conf" >/dev/null; then
+        fail "preview settings.conf must not load partition (polkit / real disks)"
+        preview_ok=0
+    fi
+    if [ -f "$PREVIEW/finished.conf" ] && ! grep -q '^restartNowMode:[[:space:]]*never' "$PREVIEW/finished.conf"; then
+        fail "preview finished.conf must set restartNowMode: never"
+        preview_ok=0
+    fi
+    if [ -f "$PREVIEW/locale.conf" ] && ! grep -q '^adjustLiveTimezone:[[:space:]]*false' "$PREVIEW/locale.conf"; then
+        fail "preview locale.conf must set adjustLiveTimezone: false"
+        preview_ok=0
+    fi
+    if [ -f "$PREVIEW/keyboard.conf" ] && ! grep -q '^useLocale1:[[:space:]]*false' "$PREVIEW/keyboard.conf"; then
+        fail "preview keyboard.conf must set useLocale1: false"
+        preview_ok=0
+    fi
+    [ "$preview_ok" -eq 1 ] && pass "preview does not partition, reboot, or push layout/timezone"
+fi
+
 # ------------------------------------------- Local AUR extras ↔ netinstall
 
 section "Local AUR extras in netinstall"


### PR DESCRIPTION
`./churros apps` abre welcome, ajustes, popups y Calamares en el host, sin construir la ISO. GTK corre en preview: HOME temporal y sin comandos que cambien el sistema.

Calamares usa un overlay temporal: no particiona, no pide Polkit y no reinicia. No sustituye `./churros run`.