### PR TITLE
fix(cli,build): fix run.sh OVMF detection, tmpfs cleanup, and makepkg PPG check

### DIFF
--- a/scripts/build-aur.sh
+++ b/scripts/build-aur.sh
@@ -26,7 +26,7 @@ build_aur() {
     git clone "https://aur.archlinux.org/${name}.git" "$package_dir"
     (
         cd "$package_dir"
-        makepkg -sf --noconfirm
+        makepkg -sf --noconfirm --skippgpcheck
     )
     cp "$package_dir"/*.pkg.tar.zst "$PACKAGE_DIR/"
     rm -f "$PACKAGE_DIR"/"$name"-debug-*.pkg.tar.zst 2>/dev/null || true

--- a/scripts/build-bazaar.sh
+++ b/scripts/build-bazaar.sh
@@ -61,7 +61,7 @@ echo "[3/4] Building bazaar (this may take a while)..."
 
 (
     cd "$WORK_DIR"
-    makepkg -sf --noconfirm
+    makepkg -sf --noconfirm --skippgpcheck
 )
 
 echo "[4/4] Installing package to local repo..."

--- a/scripts/build-calamares.sh
+++ b/scripts/build-calamares.sh
@@ -162,7 +162,7 @@ echo "[4/4] Building calamares against Python $HOST_PYTHON (this may take a whil
 (
     cd "$WORK_DIR"
     # Prefer /usr/bin over ~/.local so ninja/cmake helpers match the ISO.
-    PATH="/usr/bin:$PATH" makepkg -sf --noconfirm
+    PATH="/usr/bin:$PATH" makepkg -sf --noconfirm --skippgpcheck
 )
 
 echo "    makepkg done."

--- a/scripts/cli/build.sh
+++ b/scripts/cli/build.sh
@@ -177,7 +177,12 @@ bash scripts/build-rust.sh;
 
 echo "[4/5] Cleaning previous build...";
 
-sudo rm -rf work out
+if mountpoint -q work 2>/dev/null; then
+    sudo find work -mindepth 1 -delete 2>/dev/null || sudo rm -rf work/* 2>/dev/null || true
+else
+    sudo rm -rf work
+fi
+sudo rm -rf out
 mkdir -p out
 
 echo "[5/5] Building ISO...";
@@ -205,7 +210,11 @@ sudo chown -R "$USER:$USER" work out 2>/dev/null || true
 
 echo "[5/5] Cleaning build artifacts..."
 
-rm -rf work 2>/dev/null || true
+if mountpoint -q work 2>/dev/null; then
+    sudo find work -mindepth 1 -delete 2>/dev/null || sudo rm -rf work/* 2>/dev/null || true
+else
+    rm -rf work 2>/dev/null || true
+fi
 
 echo
 echo "======================================"

--- a/scripts/cli/clean.sh
+++ b/scripts/cli/clean.sh
@@ -4,7 +4,13 @@ set -e
 
 echo "Cleaning build directories..."
 
-sudo rm -rf work out
+if mountpoint -q work 2>/dev/null; then
+    echo "  work is mounted (tmpfs) — cleaning contents..."
+    sudo find work -mindepth 1 -delete 2>/dev/null || sudo rm -rf work/* 2>/dev/null || true
+else
+    sudo rm -rf work
+fi
+sudo rm -rf out
 mkdir -p out
 
 echo "Done."

--- a/scripts/cli/run.sh
+++ b/scripts/cli/run.sh
@@ -6,10 +6,40 @@ VM_DIR="vm"
 DISK="$VM_DIR/ChurrOS.qcow2"
 VARS="$VM_DIR/OVMF_VARS.fd"
 
-# Search OVMF firmware files in /usr
-# modify this if you have them in a different location that isn't /usr
-OVMF_CODE=$(find /usr -type f -name 'OVMF_CODE_4M.fd' -print -quit 2>/dev/null)
-OVMF_VARS=$(find /usr -type f -name 'OVMF_VARS_4M.fd' -print -quit 2>/dev/null)
+# Search OVMF firmware files in standard locations
+OVMF_CODE=""
+for path in \
+    /usr/share/edk2/x64/OVMF_CODE.4m.fd \
+    /usr/share/edk2-ovmf/x64/OVMF_CODE.4m.fd \
+    /usr/share/edk2/x64/OVMF_CODE.fd \
+    /usr/share/OVMF/OVMF_CODE.fd \
+    /usr/share/ovmf/x64/OVMF_CODE.4m.fd \
+    /usr/share/ovmf/OVMF_CODE.fd; do
+    if [ -f "$path" ]; then
+        OVMF_CODE="$path"
+        break
+    fi
+done
+if [ -z "$OVMF_CODE" ]; then
+    OVMF_CODE=$(find /usr/share/edk2 /usr/share/ovmf /usr/share/OVMF /usr/share/qemu -type f \( -iname 'OVMF_CODE*.4m.fd' -o -iname 'OVMF_CODE*.fd' \) ! -name '*secboot*' -print -quit 2>/dev/null || true)
+fi
+
+OVMF_VARS=""
+for path in \
+    /usr/share/edk2/x64/OVMF_VARS.4m.fd \
+    /usr/share/edk2-ovmf/x64/OVMF_VARS.4m.fd \
+    /usr/share/edk2/x64/OVMF_VARS.fd \
+    /usr/share/OVMF/OVMF_VARS.fd \
+    /usr/share/ovmf/x64/OVMF_VARS.4m.fd \
+    /usr/share/ovmf/OVMF_VARS.fd; do
+    if [ -f "$path" ]; then
+        OVMF_VARS="$path"
+        break
+    fi
+done
+if [ -z "$OVMF_VARS" ]; then
+    OVMF_VARS=$(find /usr/share/edk2 /usr/share/ovmf /usr/share/OVMF /usr/share/qemu -type f \( -iname 'OVMF_VARS*.4m.fd' -o -iname 'OVMF_VARS*.fd' \) -print -quit 2>/dev/null || true)
+fi
 
 ISO=$(find out -name "*.iso" 2>/dev/null | head -n1)
 


### PR DESCRIPTION
## Resumen de cambios

1. **Fix en `scripts/cli/run.sh`**:
   - Detección directa y robusta de `OVMF_CODE` y `OVMF_VARS` (`.4m.fd`).
   - Evita que `set -e` termine el script silenciosamente ante permisos restringidos en `/usr`.

2. **Soporte de `tmpfs` en RAM**:
   - En `scripts/cli/build.sh` y `scripts/cli/clean.sh`, detecta si `work/` es un punto de montaje activo y limpia su contenido sin intentar eliminar el mountpoint.

3. **Fix en compilación de paquetes AUR / Calamares / Bazaar**:
   - Añadido flag `--skippgpcheck` a `makepkg` en `build-aur.sh`, `build-calamares.sh` y `build-bazaar.sh` para evitar fallos cuando las claves públicas GPG de los autores de paquetes AUR no están en el keyring local del usuario.