### PR TITLE
feat(xfce,build): pin essential apps to XFCE panel, enable update timer, and update build scripts

### DIFF
--- a/archiso/airootfs/etc/skel/.config/systemd/user/timers.target.wants/churros-update.timer
+++ b/archiso/airootfs/etc/skel/.config/systemd/user/timers.target.wants/churros-update.timer
@@ -1,0 +1,1 @@
+../churros-update.timer

--- a/archiso/airootfs/etc/skel/.config/xfce4/panel/launcher-10/10.desktop
+++ b/archiso/airootfs/etc/skel/.config/xfce4/panel/launcher-10/10.desktop
@@ -1,0 +1,11 @@
+[Desktop Entry]
+Version=1.0
+Type=Application
+Name=Firefox
+Comment=Navegador web
+Exec=firefox %u
+Icon=firefox
+Path=
+Terminal=false
+StartupNotify=true
+Categories=Network;WebBrowser;

--- a/archiso/airootfs/etc/skel/.config/xfce4/panel/launcher-11/11.desktop
+++ b/archiso/airootfs/etc/skel/.config/xfce4/panel/launcher-11/11.desktop
@@ -1,0 +1,11 @@
+[Desktop Entry]
+Version=1.0
+Type=Application
+Name=Gestor de archivos
+Comment=Explora tus carpetas y archivos
+Exec=thunar %F
+Icon=org.xfce.thunar
+Path=
+Terminal=false
+StartupNotify=true
+Categories=System;FileManager;Utility;Core;GTK;

--- a/archiso/airootfs/etc/skel/.config/xfce4/panel/launcher-12/12.desktop
+++ b/archiso/airootfs/etc/skel/.config/xfce4/panel/launcher-12/12.desktop
@@ -1,0 +1,11 @@
+[Desktop Entry]
+Version=1.0
+Type=Application
+Name=Terminal
+Comment=Emulador de terminal
+Exec=xfce4-terminal
+Icon=org.xfce.terminal
+Path=
+Terminal=false
+StartupNotify=true
+Categories=System;TerminalEmulator;Utility;GTK;

--- a/archiso/airootfs/etc/skel/.config/xfce4/panel/launcher-13/13.desktop
+++ b/archiso/airootfs/etc/skel/.config/xfce4/panel/launcher-13/13.desktop
@@ -1,0 +1,11 @@
+[Desktop Entry]
+Version=1.0
+Type=Application
+Name=Bazaar
+Comment=Centro de aplicaciones de ChurrOS
+Exec=bazaar
+Icon=io.github.kolunmi.Bazaar
+Path=
+Terminal=false
+StartupNotify=true
+Categories=System;PackageManager;GTK;

--- a/archiso/airootfs/etc/skel/.config/xfce4/panel/launcher-14/14.desktop
+++ b/archiso/airootfs/etc/skel/.config/xfce4/panel/launcher-14/14.desktop
@@ -1,0 +1,11 @@
+[Desktop Entry]
+Version=1.0
+Type=Application
+Name=Configuracion
+Comment=Configura ChurrOS
+Exec=churros-settings
+Icon=churros-settings
+Path=
+Terminal=false
+StartupNotify=true
+Categories=Settings;GTK;

--- a/archiso/airootfs/etc/skel/.config/xfce4/xfconf/xfce-perchannel-xml/xfce4-panel.xml
+++ b/archiso/airootfs/etc/skel/.config/xfce4/xfconf/xfce-perchannel-xml/xfce4-panel.xml
@@ -12,6 +12,12 @@
       <property name="plugin-ids" type="array">
         <value type="int" value="1"/>
         <value type="int" value="2"/>
+        <value type="int" value="10"/>
+        <value type="int" value="11"/>
+        <value type="int" value="12"/>
+        <value type="int" value="13"/>
+        <value type="int" value="14"/>
+        <value type="int" value="15"/>
         <value type="int" value="3"/>
         <value type="int" value="4"/>
         <value type="int" value="5"/>
@@ -32,6 +38,34 @@
       <property name="menu-icon" type="string" value="churros-logo"/>
     </property>
     <property name="plugin-2" type="string" value="separator">
+      <property name="style" type="uint" value="0"/>
+    </property>
+    <property name="plugin-10" type="string" value="launcher">
+      <property name="items" type="array">
+        <value type="string" value="10.desktop"/>
+      </property>
+    </property>
+    <property name="plugin-11" type="string" value="launcher">
+      <property name="items" type="array">
+        <value type="string" value="11.desktop"/>
+      </property>
+    </property>
+    <property name="plugin-12" type="string" value="launcher">
+      <property name="items" type="array">
+        <value type="string" value="12.desktop"/>
+      </property>
+    </property>
+    <property name="plugin-13" type="string" value="launcher">
+      <property name="items" type="array">
+        <value type="string" value="13.desktop"/>
+      </property>
+    </property>
+    <property name="plugin-14" type="string" value="launcher">
+      <property name="items" type="array">
+        <value type="string" value="14.desktop"/>
+      </property>
+    </property>
+    <property name="plugin-15" type="string" value="separator">
       <property name="style" type="uint" value="0"/>
     </property>
     <property name="plugin-3" type="string" value="tasklist">

--- a/archiso/packages.x86_64
+++ b/archiso/packages.x86_64
@@ -4,7 +4,6 @@ arch-install-scripts
 archinstall
 base
 bcachefs-tools
-broadcom-wl
 btrfs-progs
 cryptsetup
 dhcpcd
@@ -104,7 +103,6 @@ zsh
 # GPU / Mesa (required for niri + Wayland)
 mesa
 mesa-utils
-libva-mesa-driver
 vulkan-virtio
 
 niri

--- a/archiso/packages.xfce.x86_64
+++ b/archiso/packages.xfce.x86_64
@@ -4,7 +4,6 @@ arch-install-scripts
 archinstall
 base
 bcachefs-tools
-broadcom-wl
 btrfs-progs
 cryptsetup
 dhcpcd
@@ -104,7 +103,6 @@ zsh
 # GPU / Xorg / Mesa
 mesa
 mesa-utils
-libva-mesa-driver
 vulkan-virtio
 xorg-server
 xorg-xinit

--- a/scripts/build-aur.sh
+++ b/scripts/build-aur.sh
@@ -3,8 +3,19 @@ set -e
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
-WORK_DIR="$PROJECT_DIR/work/aur-build"
 PACKAGE_DIR="$PROJECT_DIR/archiso/packages"
+
+choose_work_dir() {
+    local parent="$PROJECT_DIR/work"
+    if [ -e "$parent" ] && [ ! -w "$parent" ]; then
+        WORK_DIR="$(mktemp -d /tmp/churros-aur-build.XXXXXX)"
+        return
+    fi
+    mkdir -p "$parent"
+    WORK_DIR="$parent/aur-build"
+}
+
+choose_work_dir
 
 echo "======================================"
 echo "  Building AUR extras for ChurrOS"

--- a/scripts/build-bazaar.sh
+++ b/scripts/build-bazaar.sh
@@ -3,8 +3,19 @@ set -e
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
-WORK_DIR="$PROJECT_DIR/work/bazaar-build"
 PACKAGE_DIR="$PROJECT_DIR/archiso/packages"
+
+choose_work_dir() {
+    local parent="$PROJECT_DIR/work"
+    if [ -e "$parent" ] && [ ! -w "$parent" ]; then
+        WORK_DIR="$(mktemp -d /tmp/churros-bazaar-build.XXXXXX)"
+        return
+    fi
+    mkdir -p "$parent"
+    WORK_DIR="$parent/bazaar-build"
+}
+
+choose_work_dir
 
 echo "======================================"
 echo "  Building Bazaar app store from Arch"

--- a/scripts/cli/build.sh
+++ b/scripts/cli/build.sh
@@ -145,10 +145,10 @@ echo "[2/5] Checking packages..."
 bash scripts/build-calamares.sh
 CALAMARES_PKG=$(ls archiso/packages/calamares-[0-9]*.pkg.tar.zst 2>/dev/null | head -1 || true)
 PYWAL_PKG=$(ls archiso/packages/python-pywal-*.pkg.tar.zst 2>/dev/null | head -1 || true)
-WAYPAPER_PKG=$(ls archiso/packages/waypaper-*.pkg.tar.zst 2>/dev/null | head -1 || true)
+YAY_PKG=$(ls archiso/packages/yay-*.pkg.tar.zst 2>/dev/null | head -1 || true)
 BAZAAR_PKG=$(ls archiso/packages/bazaar-*.pkg.tar.zst 2>/dev/null | head -1 || true)
 
-if [ -z "$PYWAL_PKG" ] || [ -z "$WAYPAPER_PKG" ]; then
+if [ -z "$PYWAL_PKG" ] || [ -z "$YAY_PKG" ]; then
     echo "  AUR extras not found — building..."
     bash scripts/build-aur.sh
 fi


### PR DESCRIPTION
## Resumen de cambios

1. **Retoques en la barra de tareas de XFCE**:
   - Se anclaron 5 aplicaciones esenciales al panel inferior (Firefox, Thunar, Terminal XFCE, Tienda Bazaar, Configuración de ChurrOS), excluyendo `churros-welcome`.
   - Se crearon sus respectivos accesos directos `.desktop` en `archiso/airootfs/etc/skel/.config/xfce4/panel/`.

2. **Actualizaciones automáticas por defecto**:
   - Añadido el enlace simbólico `timers.target.wants/churros-update.timer` en `/etc/skel` para que las actualizaciones automáticas queden activas desde el primer arranque en ambas ediciones (Niri y XFCE).

3. **Corrección en listas de paquetes oficiales**:
   - Eliminados los paquetes obsoletos `broadcom-wl` y `libva-mesa-driver` de `packages.x86_64` y `packages.xfce.x86_64`.

4. **Mejoras en scripts de compilación**:
   - `build-aur.sh` y `build-bazaar.sh` usan un fallback a `/tmp/` si `work/` no tiene permisos de escritura debido a ejecuciones previas de `sudo mkarchiso`.
   - `build.sh` ahora comprueba correctamente la presencia de `yay` en lugar de `waypaper` para evitar recompilaciones innecesarias de AUR.