### PR TITLE
Feat/command line editing zsh

### DIFF
--- a/archiso/airootfs/etc/skel/.config/foot/foot.ini
+++ b/archiso/airootfs/etc/skel/.config/foot/foot.ini
@@ -6,6 +6,11 @@ shell=zsh
 term=xterm-256color
 bold-text-in-bright=yes
 
+# Need a new key bind to make ctrl + backspace 
+## sends the correct escape sequence to zsh
+[key-bindings]
+ctrl+backspace=\e[99~
+
 [cursor]
 style=beam
 blink=yes

--- a/archiso/airootfs/etc/skel/.config/foot/foot.ini
+++ b/archiso/airootfs/etc/skel/.config/foot/foot.ini
@@ -8,6 +8,7 @@ bold-text-in-bright=yes
 
 # Need a new key bind to make ctrl + backspace 
 ## sends the correct escape sequence to zsh
+### tested and working
 [text-bindings]
 \x1b[99~ = Control+BackSpace
 

--- a/archiso/airootfs/etc/skel/.config/foot/foot.ini
+++ b/archiso/airootfs/etc/skel/.config/foot/foot.ini
@@ -8,8 +8,8 @@ bold-text-in-bright=yes
 
 # Need a new key bind to make ctrl + backspace 
 ## sends the correct escape sequence to zsh
-[key-bindings]
-ctrl+backspace=text-input:\e[99~
+[text-bindings]
+\x1b[99~ = Control+BackSpace
 
 [cursor]
 style=beam

--- a/archiso/airootfs/etc/skel/.config/foot/foot.ini
+++ b/archiso/airootfs/etc/skel/.config/foot/foot.ini
@@ -9,7 +9,7 @@ bold-text-in-bright=yes
 # Need a new key bind to make ctrl + backspace 
 ## sends the correct escape sequence to zsh
 [key-bindings]
-ctrl+backspace=\e[99~
+ctrl+backspace=text-input:\e[99~
 
 [cursor]
 style=beam

--- a/archiso/airootfs/etc/skel/.zshrc
+++ b/archiso/airootfs/etc/skel/.zshrc
@@ -56,10 +56,12 @@ zle -N power-delete
 # ==============================================================
 # KEY BINDINGS
 
+# tested and working
 # Normal word movement
 bindkey $'\e[1;5D' power-left
 bindkey $'\e[1;5C' power-right
 
+# ctrl+del works ctrl + backspace is being fixed
 # Delete words
 bindkey $'\e[99~' power-backspace
 bindkey $'\e[3;5~' power-delete

--- a/archiso/airootfs/etc/skel/.zshrc
+++ b/archiso/airootfs/etc/skel/.zshrc
@@ -62,7 +62,7 @@ bindkey $'\e[1;5C' power-right
 
 # Delete words
 bindkey $'\e[99~' power-backspace
-bindkey $'\e[98~' power-delete
+bindkey $'\e[3;5~' power-delete
 
 # --- Prompt (starship style) ---
 setopt PROMPT_SUBST EXTENDED_GLOB

--- a/archiso/airootfs/etc/skel/.zshrc
+++ b/archiso/airootfs/etc/skel/.zshrc
@@ -11,6 +11,59 @@ setopt SHARE_HISTORY
 autoload -Uz compinit
 compinit
 
+# ============================================================
+# NORMAL WORD MOVEMENT
+
+# Ctrl + Left
+power-left() {
+    REGION_ACTIVE=0
+    zle backward-word
+}
+
+# Ctrl + Right
+power-right() {
+    REGION_ACTIVE=0
+    zle forward-word
+}
+
+zle -N power-left
+zle -N power-right
+
+# ============================================================
+# DELETE WORD
+
+# Ctrl + Backspace
+power-backspace() {
+    if (( REGION_ACTIVE )); then
+        zle kill-region
+    else
+        zle backward-kill-word
+    fi
+}
+
+# Ctrl + Delete
+power-delete() {
+    if (( REGION_ACTIVE )); then
+        zle kill-region
+    else
+        zle kill-word
+    fi
+}
+
+zle -N power-backspace
+zle -N power-delete
+
+# ==============================================================
+# KEY BINDINGS
+
+# Normal word movement
+bindkey $'\e[1;5D' power-left
+bindkey $'\e[1;5C' power-right
+
+# Delete words
+bindkey $'\e[99~' power-backspace
+bindkey $'\e[98~' power-delete
+
 # --- Prompt (starship style) ---
 setopt PROMPT_SUBST EXTENDED_GLOB
 

--- a/archiso/airootfs/etc/skel/.zshrc
+++ b/archiso/airootfs/etc/skel/.zshrc
@@ -61,7 +61,8 @@ zle -N power-delete
 bindkey $'\e[1;5D' power-left
 bindkey $'\e[1;5C' power-right
 
-# ctrl+del works ctrl + backspace is being fixed
+# ctrl+del tested and working
+## ctrl + backspace tested and working
 # Delete words
 bindkey $'\e[99~' power-backspace
 bindkey $'\e[3;5~' power-delete


### PR DESCRIPTION
## Resumen
Permite hacer command line editing. 

se anadieron cosas a .zshrc y se modifico foot.ini para anadir una secuencia de escape cuando se hiciera ctrl+backspace.

se puede ampliar para la adicion de nuevos shortcuts que la estadia en la terminal sea mas facil 

## Cómo se probó

- [ ] `./churros check`
- [ ] `./churros build` 
- [x] ./churros run`

## Notas
cualquier mejora al posicionamiento del codigo es bienvenida
https://github.com/user-attachments/assets/6c1f77fc-250f-4f45-81c9-8a57bcc254c6


